### PR TITLE
Add a toBeInteger matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ If you've come here to help contribute - Thanks! Take a look at the [contributin
     - [.toBeEven()](#tobeeven)
     - [.toBeOdd()](#tobeodd)
     - [.toBeWithin(start, end)](#tobewithinstart-end)
+    - [.toBeInteger()](#tobeinteger)
   - [Object](#object)
     - [.toBeObject()](#tobeobject)
     - [.toContainKey(key)](#tocontainkeykey)
@@ -596,6 +597,18 @@ test('passes when number is within given bounds', () => {
   expect(1).toBeWithin(1, 3);
   expect(2).toBeWithin(1, 3);
   expect(3).not.toBeWithin(1, 3);
+});
+```
+
+#### .toBeInteger()
+
+Use `.toBeInteger` when checking if a number is an integer.
+
+```js
+test('passes when value is an integer', () => {
+  expect(1).toBeInteger();
+  expect(1.0).toBeInteger();
+  expect(1.1).not.toBeInteger();
 });
 ```
 

--- a/src/matchers/toBeInteger/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeInteger/__snapshots__/index.test.js.snap
@@ -3,13 +3,13 @@
 exports[`.not.toBeInteger fails when given integer 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toBeInteger(</><dim>)</>
 
-Expected value to not be a integer received:
+Expected value to not be an integer received:
   <red>1</>"
 `;
 
 exports[`.toBeInteger fails when given fraction 1`] = `
 "<dim>expect(</><red>received</><dim>).toBeInteger(</><dim>)</>
 
-Expected value to be a integer received:
+Expected value to be an integer received:
   <red>1.5</>"
 `;

--- a/src/matchers/toBeInteger/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeInteger/__snapshots__/index.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toBeInteger fails when given integer 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toBeInteger(</><dim>)</>
+
+Expected value to not be a integer received:
+  <red>1</>"
+`;
+
+exports[`.toBeInteger fails when given fraction 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeInteger(</><dim>)</>
+
+Expected value to be a integer received:
+  <red>1.5</>"
+`;

--- a/src/matchers/toBeInteger/index.js
+++ b/src/matchers/toBeInteger/index.js
@@ -1,0 +1,26 @@
+import { matcherHint, printReceived } from 'jest-matcher-utils';
+
+import predicate from './predicate';
+
+const passMessage = received => () =>
+  matcherHint('.not.toBeInteger', 'received', '') +
+  '\n\n' +
+  'Expected value to not be an integer received:\n' +
+  `  ${printReceived(received)}`;
+
+const failMessage = received => () =>
+  matcherHint('.toBeInteger', 'received', '') +
+  '\n\n' +
+  'Expected value to be an integer received:\n' +
+  `  ${printReceived(received)}`;
+
+export default {
+  toBeInteger: expected => {
+    const pass = predicate(expected);
+    if (pass) {
+      return { pass: true, message: passMessage(expected) };
+    }
+
+    return { pass: false, message: failMessage(expected) };
+  }
+};

--- a/src/matchers/toBeInteger/index.test.js
+++ b/src/matchers/toBeInteger/index.test.js
@@ -1,0 +1,23 @@
+import matcher from './';
+
+expect.extend(matcher);
+
+describe('.toBeInteger', () => {
+  test('passes when given integer', () => {
+    expect(1).toBeInteger();
+  });
+
+  test('fails when given fraction', () => {
+    expect(() => expect(1.5).toBeInteger()).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toBeInteger', () => {
+  test('passes when given fraction', () => {
+    expect(1.5).not.toBeInteger();
+  });
+
+  test('fails when given integer', () => {
+    expect(() => expect(1).not.toBeInteger()).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/toBeInteger/predicate.js
+++ b/src/matchers/toBeInteger/predicate.js
@@ -1,0 +1,4 @@
+const isNumber = value => !isNaN(parseInt(value));
+const isInteger = value => Number.isInteger(+value);
+
+export default value => isNumber(value) && isInteger(value);

--- a/src/matchers/toBeInteger/predicate.test.js
+++ b/src/matchers/toBeInteger/predicate.test.js
@@ -1,0 +1,27 @@
+import predicate from './predicate';
+
+describe('toBeInteger Predicate', () => {
+  describe('returns true', () => {
+    test('When integer is passed', () => {
+      expect(predicate(1)).toBe(true);
+      expect(predicate(0)).toBe(true);
+      expect(predicate(-1)).toBe(true);
+      expect(predicate('1')).toBe(true);
+    });
+  });
+
+  describe('return false', () => {
+    test('When fraction is passed', () => {
+      expect(predicate(1.1)).toBe(false);
+      expect(predicate(0.1)).toBe(false);
+      expect(predicate(-1.1)).toBe(false);
+      expect(predicate('1.1')).toBe(false);
+    });
+
+    test('When NaN is passed', () => {
+      expect(predicate(NaN)).toBe(false);
+      expect(predicate('Not a number!')).toBe(false);
+      expect(predicate({})).toBe(false);
+    });
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -187,6 +187,11 @@ declare namespace jest {
     toBeWithin(start: number, end: number): R;
 
     /**
+     * Use `.toBeInteger` when checking if a value is an integer.
+     */
+    toBeInteger(): R;
+
+    /**
      * Use `.toBeObject` when checking if a value is an `Object`.
      */
     toBeObject(): R;


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/279.

> ### What
> Add a new matcher `.toBeInteger`
> 
> ### Why
> #278
> 
> ### Housekeeping
> * [x]  Unit tests
> * [x]  Documentation is up to date
> * [x]  No additional lint warnings
> * [x]  [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant