### PR TITLE
Closes #226 Add matcher for Array.toSatisfyAny

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ If you've come here to help contribute - Thanks! Take a look at the [contributin
     - [.toIncludeAnyMembers([members])](#toincludeanymembersmembers)
     - [.toIncludeSameMembers([members])](#toincludesamemembersmembers)
     - [.toSatisfyAll(predicate)](#tosatisfyallpredicate)
+    - [.toSatisfyAny(predicate)](#tosatisfyanypredicate)
   - [Boolean](#boolean)
     - [.toBeBoolean()](#tobeboolean)
     - [.toBeTrue()](#tobetrue)
@@ -326,6 +327,18 @@ test('passes when all values in array pass given predicate', () => {
   const isOdd = el => el % 2 === 1;
   expect([1,3,5,7]).toSatisfyAll(isOdd);
   expect([1,3,4,5,7]).not.toSatisfyAll(isOdd);
+});
+```
+
+#### .toSatisfyAny(predicate)
+
+Use `.toSatisfyAny` when you want to use a custom matcher by supplying a predicate function that returns `true` for any matching value in an array.
+
+```js
+test('passes when any value in array pass given predicate', () => {
+  const isOdd = el => el % 2 === 1;
+  expect([2,3,6,8]).toSatisfyAny(isOdd);
+  expect([2,4,8,12]).not.toSatisfyAny(isOdd);
 });
 ```
 

--- a/src/matchers/toSatisfyAny/__snapshots__/index.test.js.snap
+++ b/src/matchers/toSatisfyAny/__snapshots__/index.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toSatisfyAll fails when any value satisfies predicate 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toSatisfyAny(</><green>expected</><dim>)</>
+
+Expected array to not satisfy predicate for any value:
+  <green>[Function isOdd]</>
+Received:
+  <red>[2, 3, 6, 8]</>"
+`;
+
+exports[`.toSatisfyAny fails when no value satisfies the predicate 1`] = `
+"<dim>expect(</><red>received</><dim>).toSatisfyAny(</><green>expected</><dim>)</>
+
+Expected array to satisfy predicate for any values:
+  <green>[Function isOdd]</>
+Received:
+  <red>[2, 4, 6, 8]</>"
+`;

--- a/src/matchers/toSatisfyAny/index.js
+++ b/src/matchers/toSatisfyAny/index.js
@@ -1,0 +1,30 @@
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+
+import predicate from './predicate';
+
+const passMessage = (actual, expected) => () =>
+  matcherHint('.not.toSatisfyAny') +
+  '\n\n' +
+  'Expected array to not satisfy predicate for any value:\n' +
+  `  ${printExpected(expected)}\n` +
+  'Received:\n' +
+  `  ${printReceived(actual)}`;
+
+const failMessage = (actual, expected) => () =>
+  matcherHint('.toSatisfyAny') +
+  '\n\n' +
+  'Expected array to satisfy predicate for any values:\n' +
+  `  ${printExpected(expected)}\n` +
+  'Received:\n' +
+  `  ${printReceived(actual)}`;
+
+export default {
+  toSatisfyAny: (actual, expected) => {
+    const pass = predicate(actual, expected);
+    if (pass) {
+      return { pass: true, message: passMessage(actual, expected) };
+    }
+
+    return { pass: false, message: failMessage(actual, expected) };
+  }
+};

--- a/src/matchers/toSatisfyAny/index.test.js
+++ b/src/matchers/toSatisfyAny/index.test.js
@@ -1,0 +1,30 @@
+import matcher from './';
+
+expect.extend(matcher);
+
+let isEven = el => el % 2 === 0;
+let isOdd = el => el % 2 === 1;
+
+describe('.toSatisfyAny', () => {
+  test('passes when any values satisfy predicate', () => {
+    expect([2, 3, 6, 8]).toSatisfyAny(isOdd);
+    expect([1, 4, 7, 9]).toSatisfyAny(isEven);
+    expect([11]).toSatisfyAny(isOdd);
+    expect([10]).toSatisfyAny(isEven);
+  });
+
+  test('fails when no value satisfies the predicate', () => {
+    expect(() => expect([2, 4, 6, 8]).toSatisfyAny(isOdd)).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toSatisfyAll', () => {
+  test('passes when all values does not satisfy the predicate', () => {
+    expect([2, 4, 6, 8]).not.toSatisfyAny(isOdd);
+    expect([1, 3, 5, 7]).not.toSatisfyAny(isEven);
+  });
+
+  test('fails when any value satisfies predicate', () => {
+    expect(() => expect([2, 3, 6, 8]).not.toSatisfyAny(isOdd)).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/toSatisfyAny/predicate.js
+++ b/src/matchers/toSatisfyAny/predicate.js
@@ -1,0 +1,1 @@
+export default (array, predicate) => array.some(predicate);

--- a/src/matchers/toSatisfyAny/predicate.test.js
+++ b/src/matchers/toSatisfyAny/predicate.test.js
@@ -1,0 +1,25 @@
+import predicate from './predicate';
+
+describe('toSatisfyAny', () => {
+  let isOdd = el => el % 2 === 1;
+
+  describe('returns true', () => {
+    test('when any elements satisfy', () => {
+      expect(predicate([2, 3, 6, 8], isOdd)).toBe(true);
+    });
+
+    test('works for repeated elements', () => {
+      expect(predicate([2, 3, 3, 8], isOdd)).toBe(true);
+    });
+  });
+
+  describe('returns false', () => {
+    test('when all elements fail', () => {
+      expect(predicate([10, 2, 4, 6], isOdd)).toBe(false);
+    });
+
+    test('works for repeated elements', () => {
+      expect(predicate([2, 4, 4, 8, 10], isOdd)).toBe(false);
+    });
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -89,6 +89,12 @@ declare namespace jest {
     toSatisfyAll(predicate: (x: any) => boolean): R;
 
     /**
+     * Use `.toSatisfyAny` when you want to use a custom matcher by supplying a predicate function that returns `true` for any matching value in an array.
+     * @param {Function} predicate
+     */
+    toSatisfyAny(predicate: (x: any) => boolean): R;
+
+    /**
      * Use `.toBeBoolean` when checking if a value is a `Boolean`.
      */
     toBeBoolean(): R;
@@ -443,6 +449,12 @@ declare namespace jest {
      * @param {Function} predicate
      */
     toSatisfyAll(predicate: (x: any) => boolean): any;
+
+    /**
+     * Use `.toSatisfyAny` when you want to use a custom matcher by supplying a predicate function that returns `true` for any matching value in an array.
+     * @param {Function} predicate
+     */
+    toSatisfyAny(predicate: (x: any) => boolean): any;
 
     /**
      * Use `.toBeBoolean` when checking if a value is a `Boolean`.


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/227

> ### What
> Feature: Add matcher for Array.toSatisfyAny
> 
> ### Why
> This is a matcher I find myself in common need of.
> 
> ### Notes
> Similar to `Array.toSatisfyAll` but uses `Array.some` instead of `Array.every`
> 
> ### Housekeeping
> * [✓] Unit tests
> * [✓] Documentation is up to date
> * [✓] No additional lint warnings
> * [✓] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant