### PR TITLE
Fix GH Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - run: yarn install
       - run: yarn test:coverage
       - run: yarn lint
       - run: yarn test:report

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,5 @@
-name: GitHub CI
+name: 'GitHub CI'
+on:
   push:
     branches: [ master ]
   pull_request:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "yarn build",
     "precommit": "lint-staged",
     "prettier": "prettier 'src/**/*.js' --write --single-quote=true --print-width=120",
-    "test": "jest",
+    "test": "jest --color=false",
     "test:coverage": "yarn test -- --coverage",
     "test:report": "codecov",
     "test:watch": "yarn test -- --watch"

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   "license": "MIT",
   "repository": "jest-community/jest-extended",
   "devDependencies": {
-    "@types/jest": "^23.3.2",
+    "@types/jest": "^24.0.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.1",
-    "babel-jest": "^23.0.1",
+    "babel-jest": "^24.0.0",
     "babel-jest-assertions": "^0.1.0",
     "babel-plugin-gwt": "^1.0.0",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
@@ -51,7 +51,7 @@
     "eslint-plugin-jest": "^21.2.0",
     "husky": "^0.14.3",
     "import-all.macro": "^2.0.3",
-    "jest": "^23.0.1",
+    "jest": "^24.0.0",
     "jest-each": "^0.5.0",
     "jest-watch-typeahead": "^0.2.0",
     "lint-staged": "^6.0.0",
@@ -99,7 +99,7 @@
       "babel-plugin-transform-es2015-modules-commonjs",
       "transform-object-rest-spread",
       "transform-async-to-generator",
-      "babel-jest-assertions",
+      "./node_modules/babel-jest-assertions",
       "gwt",
       "macros"
     ]

--- a/src/matchers/toBeAfter/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeAfter/__snapshots__/index.test.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeAfter fails when given a later date 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeAfter(</><dim>)</>
+"expect(received).not.toBeAfter()
 
-Expected date to be after <red>2018-06-01T22:00:00.000Z</> but received:
-  <red>2018-06-02T22:00:00.000Z</>"
+Expected date to be after 2018-06-01T22:00:00.000Z but received:
+  2018-06-02T22:00:00.000Z"
 `;
 
 exports[`.toBeAfter fails when given an earlier date 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeAfter(</><dim>)</>
+"expect(received).toBeAfter()
 
-Expected date to be after <red>2018-06-02T22:00:00.000Z</> but received:
-  <red>2018-06-01T22:00:00.000Z</>"
+Expected date to be after 2018-06-02T22:00:00.000Z but received:
+  2018-06-01T22:00:00.000Z"
 `;

--- a/src/matchers/toBeArray/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeArray/__snapshots__/index.test.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeArray fails when given an array 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeArray(</><dim>)</>
+"expect(received).not.toBeArray()
 
 Expected value to not be an array received:
-  <red>[]</>"
+  []"
 `;
 
 exports[`.toBeArray fails when not given an array 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeArray(</><dim>)</>
+"expect(received).toBeArray()
 
 Expected value to be an array received:
-  <red>false</>"
+  false"
 `;

--- a/src/matchers/toBeArrayOfSize/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeArrayOfSize/__snapshots__/index.test.js.snap
@@ -1,131 +1,131 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeArrayOfSize fails when given an array of size 0 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeArrayOfSize(</><green>expected</><dim>)</>
+"expect(received).not.toBeArrayOfSize(expected)
 
 Expected value to not be an array of size:
-  <green>0</>
+  0
 Received:
-  value: <red>[]</>
-  length: <red>\\"Not Accessible\\"</>"
+  value: []
+  length: \\"Not Accessible\\""
 `;
 
 exports[`.toBeArrayOfSize fails when given neither a parameter nor an array 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeArrayOfSize(</><green>expected</><dim>)</>
+"expect(received).toBeArrayOfSize(expected)
 
 Expected value to be an array of size:
-  <green>undefined</>
+  undefined
 Received:
-  value: <red>[]</>
-  length: <red>\\"Not Accessible\\"</>"
+  value: []
+  length: \\"Not Accessible\\""
 `;
 
 exports[`.toBeArrayOfSize fails when given type of [object Object] which is not an array 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeArrayOfSize(</><green>expected</><dim>)</>
+"expect(received).toBeArrayOfSize(expected)
 
 Expected value to be an array of size:
-  <green>1</>
+  1
 Received:
-  value: <red>{}</>
-  length: <red>\\"Not Accessible\\"</>"
+  value: {}
+  length: \\"Not Accessible\\""
 `;
 
 exports[`.toBeArrayOfSize fails when given type of 0 which is not an array 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeArrayOfSize(</><green>expected</><dim>)</>
+"expect(received).toBeArrayOfSize(expected)
 
 Expected value to be an array of size:
-  <green>1</>
+  1
 Received:
-  value: <red>0</>
-  length: <red>\\"Not Accessible\\"</>"
+  value: 0
+  length: \\"Not Accessible\\""
 `;
 
 exports[`.toBeArrayOfSize fails when given type of NaN which is not an array 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeArrayOfSize(</><green>expected</><dim>)</>
+"expect(received).toBeArrayOfSize(expected)
 
 Expected value to be an array of size:
-  <green>1</>
+  1
 Received:
-  value: <red>NaN</>
-  length: <red>\\"Not Accessible\\"</>"
+  value: NaN
+  length: \\"Not Accessible\\""
 `;
 
 exports[`.toBeArrayOfSize fails when given type of false which is not an array 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeArrayOfSize(</><green>expected</><dim>)</>
+"expect(received).toBeArrayOfSize(expected)
 
 Expected value to be an array of size:
-  <green>1</>
+  1
 Received:
-  value: <red>false</>
-  length: <red>\\"Not Accessible\\"</>"
+  value: false
+  length: \\"Not Accessible\\""
 `;
 
 exports[`.toBeArrayOfSize fails when given type of null which is not an array 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeArrayOfSize(</><green>expected</><dim>)</>
+"expect(received).toBeArrayOfSize(expected)
 
 Expected value to be an array of size:
-  <green>1</>
+  1
 Received:
-  value: <red>null</>
-  length: <red>\\"Not Accessible\\"</>"
+  value: null
+  length: \\"Not Accessible\\""
 `;
 
 exports[`.toBeArrayOfSize fails when given type of true which is not an array 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeArrayOfSize(</><green>expected</><dim>)</>
+"expect(received).toBeArrayOfSize(expected)
 
 Expected value to be an array of size:
-  <green>1</>
+  1
 Received:
-  value: <red>true</>
-  length: <red>\\"Not Accessible\\"</>"
+  value: true
+  length: \\"Not Accessible\\""
 `;
 
 exports[`.toBeArrayOfSize fails when given type of undefined which is not an array 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeArrayOfSize(</><green>expected</><dim>)</>
+"expect(received).toBeArrayOfSize(expected)
 
 Expected value to be an array of size:
-  <green>1</>
+  1
 Received:
-  value: <red>[Function anonymous]</>
-  length: <red>\\"Not Accessible\\"</>"
+  value: [Function anonymous]
+  length: \\"Not Accessible\\""
 `;
 
 exports[`.toBeArrayOfSize fails when given type of undefined which is not an array 2`] = `
-"<dim>expect(</><red>received</><dim>).toBeArrayOfSize(</><green>expected</><dim>)</>
+"expect(received).toBeArrayOfSize(expected)
 
 Expected value to be an array of size:
-  <green>1</>
+  1
 Received:
-  value: <red>undefined</>
-  length: <red>\\"Not Accessible\\"</>"
+  value: undefined
+  length: \\"Not Accessible\\""
 `;
 
 exports[`.toBeArrayOfSize fails when given type which is not an array 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeArrayOfSize(</><green>expected</><dim>)</>
+"expect(received).toBeArrayOfSize(expected)
 
 Expected value to be an array of size:
-  <green>1</>
+  1
 Received:
-  value: <red>false</>
-  length: <red>\\"Not Accessible\\"</>"
+  value: false
+  length: \\"Not Accessible\\""
 `;
 
 exports[`.toBeArrayOfSize fails when not given a parameter 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeArrayOfSize(</><green>expected</><dim>)</>
+"expect(received).toBeArrayOfSize(expected)
 
 Expected value to be an array of size:
-  <green>undefined</>
+  undefined
 Received:
-  value: <red>[1]</>
-  length: <red>1</>"
+  value: [1]
+  length: 1"
 `;
 
 exports[`.toBeArrayOfSize fails when not given an array 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeArrayOfSize(</><green>expected</><dim>)</>
+"expect(received).toBeArrayOfSize(expected)
 
 Expected value to be an array of size:
-  <green>5</>
+  5
 Received:
-  value: <red>undefined</>
-  length: <red>\\"Not Accessible\\"</>"
+  value: undefined
+  length: \\"Not Accessible\\""
 `;

--- a/src/matchers/toBeBefore/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeBefore/__snapshots__/index.test.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeBefore fails when given an earlier date 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeBefore(</><dim>)</>
+"expect(received).not.toBeBefore()
 
-Expected date to be before <red>2018-06-02T22:00:00.000Z</> but received:
-  <red>2018-06-01T22:00:00.000Z</>"
+Expected date to be before 2018-06-02T22:00:00.000Z but received:
+  2018-06-01T22:00:00.000Z"
 `;
 
 exports[`.toBeBefore fails when given a later date 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeBefore(</><dim>)</>
+"expect(received).toBeBefore()
 
-Expected date to be before <red>2018-06-01T22:00:00.000Z</> but received:
-  <red>2018-06-02T22:00:00.000Z</>"
+Expected date to be before 2018-06-01T22:00:00.000Z but received:
+  2018-06-02T22:00:00.000Z"
 `;

--- a/src/matchers/toBeBoolean/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeBoolean/__snapshots__/index.test.js.snap
@@ -1,22 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeBoolean fails when given a boolean 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeBoolean(</><dim>)</>
+"expect(received).not.toBeBoolean()
 
 Expected value to not be of type boolean, received:
-  <red>true</>"
+  true"
 `;
 
 exports[`.not.toBeBoolean fails when given an object of type boolean 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeBoolean(</><dim>)</>
+"expect(received).not.toBeBoolean()
 
 Expected value to not be of type boolean, received:
-  <red>{}</>"
+  {}"
 `;
 
 exports[`.toBeBoolean fails when not given a boolean 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeBoolean(</><dim>)</>
+"expect(received).toBeBoolean()
 
 Expected value to be of type boolean, received:
-  <red>1</>"
+  1"
 `;

--- a/src/matchers/toBeDate/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeDate/__snapshots__/index.test.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeDate fails when given a date 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeDate(</><dim>)</>
+"expect(received).not.toBeDate()
 
 Expected value to not be a date received:
-  <red>2018-01-01T13:00:00.000Z</>"
+  2018-01-01T13:00:00.000Z"
 `;
 
 exports[`.toBeDate fails when not given a date 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeDate(</><dim>)</>
+"expect(received).toBeDate()
 
 Expected value to be a date received:
-  <red>false</>"
+  false"
 `;

--- a/src/matchers/toBeEmpty/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeEmpty/__snapshots__/index.test.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeEmpty fails when given empty string 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeEmpty(</><dim>)</>
+"expect(received).not.toBeEmpty()
 
 Expected value to not be empty received:
-  <red>\\"\\"</>"
+  \\"\\""
 `;
 
 exports[`.toBeEmpty fails when given non-empty string 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeEmpty(</><dim>)</>
+"expect(received).toBeEmpty()
 
 Expected value to be empty received:
-  <red>\\"string\\"</>"
+  \\"string\\""
 `;

--- a/src/matchers/toBeEven/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeEven/__snapshots__/index.test.js.snap
@@ -1,71 +1,71 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeEven fails when given an even number 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeEven(</><dim>)</>
+"expect(received).not.toBeEven()
 
 Expected value to not be an even number received:
- <red>2</>"
+ 2"
 `;
 
 exports[`.toBeEven fails when not given an even number 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeEven(</><dim>)</>
+"expect(received).toBeEven()
 
 Expected value to be an even number received:
- <red>false</>"
+ false"
 `;
 
 exports[`.toBeEven fails when not given an even number 2`] = `
-"<dim>expect(</><red>received</><dim>).toBeEven(</><dim>)</>
+"expect(received).toBeEven()
 
 Expected value to be an even number received:
- <red>true</>"
+ true"
 `;
 
 exports[`.toBeEven fails when not given an even number 3`] = `
-"<dim>expect(</><red>received</><dim>).toBeEven(</><dim>)</>
+"expect(received).toBeEven()
 
 Expected value to be an even number received:
- <red>\\"\\"</>"
+ \\"\\""
 `;
 
 exports[`.toBeEven fails when not given an even number 4`] = `
-"<dim>expect(</><red>received</><dim>).toBeEven(</><dim>)</>
+"expect(received).toBeEven()
 
 Expected value to be an even number received:
- <red>1</>"
+ 1"
 `;
 
 exports[`.toBeEven fails when not given an even number 5`] = `
-"<dim>expect(</><red>received</><dim>).toBeEven(</><dim>)</>
+"expect(received).toBeEven()
 
 Expected value to be an even number received:
- <red>{}</>"
+ {}"
 `;
 
 exports[`.toBeEven fails when not given an even number 6`] = `
-"<dim>expect(</><red>received</><dim>).toBeEven(</><dim>)</>
+"expect(received).toBeEven()
 
 Expected value to be an even number received:
- <red>[Function anonymous]</>"
+ [Function anonymous]"
 `;
 
 exports[`.toBeEven fails when not given an even number 7`] = `
-"<dim>expect(</><red>received</><dim>).toBeEven(</><dim>)</>
+"expect(received).toBeEven()
 
 Expected value to be an even number received:
- <red>undefined</>"
+ undefined"
 `;
 
 exports[`.toBeEven fails when not given an even number 8`] = `
-"<dim>expect(</><red>received</><dim>).toBeEven(</><dim>)</>
+"expect(received).toBeEven()
 
 Expected value to be an even number received:
- <red>null</>"
+ null"
 `;
 
 exports[`.toBeEven fails when not given an even number 9`] = `
-"<dim>expect(</><red>received</><dim>).toBeEven(</><dim>)</>
+"expect(received).toBeEven()
 
 Expected value to be an even number received:
- <red>NaN</>"
+ NaN"
 `;

--- a/src/matchers/toBeExtensible/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeExtensible/__snapshots__/index.test.js.snap
@@ -1,81 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeExtensible fails when given an extensible object:  1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeExtensible(</><dim>)</>
+"expect(received).not.toBeExtensible()
 
 Expected value to not be extensible received:
-  <green>[]</>
+  []
 "
 `;
 
 exports[`.not.toBeExtensible fails when given an extensible object: [object Object] 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeExtensible(</><dim>)</>
+"expect(received).not.toBeExtensible()
 
 Expected value to not be extensible received:
-  <green>{}</>
+  {}
 "
 `;
 
 exports[`.not.toBeExtensible fails when given an extensible object: undefined 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeExtensible(</><dim>)</>
+"expect(received).not.toBeExtensible()
 
 Expected value to not be extensible received:
-  <green>[Function anonymous]</>
+  [Function anonymous]
 "
 `;
 
 exports[`.toBeExtensible fails when not given an extensible object:  1`] = `
-"<dim>expect(</><red>received</><dim>).toBeExtensible(</><dim>)</>
+"expect(received).toBeExtensible()
 
 Expected value to be extensible received:
-  <red>\\"\\"</>"
+  \\"\\""
 `;
 
 exports[`.toBeExtensible fails when not given an extensible object: [object Object] 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeExtensible(</><dim>)</>
+"expect(received).toBeExtensible()
 
 Expected value to be extensible received:
-  <red>{}</>"
+  {}"
 `;
 
 exports[`.toBeExtensible fails when not given an extensible object: [object Object] 2`] = `
-"<dim>expect(</><red>received</><dim>).toBeExtensible(</><dim>)</>
+"expect(received).toBeExtensible()
 
 Expected value to be extensible received:
-  <red>{}</>"
+  {}"
 `;
 
 exports[`.toBeExtensible fails when not given an extensible object: 0 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeExtensible(</><dim>)</>
+"expect(received).toBeExtensible()
 
 Expected value to be extensible received:
-  <red>0</>"
+  0"
 `;
 
 exports[`.toBeExtensible fails when not given an extensible object: NaN 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeExtensible(</><dim>)</>
+"expect(received).toBeExtensible()
 
 Expected value to be extensible received:
-  <red>NaN</>"
+  NaN"
 `;
 
 exports[`.toBeExtensible fails when not given an extensible object: false 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeExtensible(</><dim>)</>
+"expect(received).toBeExtensible()
 
 Expected value to be extensible received:
-  <red>false</>"
+  false"
 `;
 
 exports[`.toBeExtensible fails when not given an extensible object: null 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeExtensible(</><dim>)</>
+"expect(received).toBeExtensible()
 
 Expected value to be extensible received:
-  <red>null</>"
+  null"
 `;
 
 exports[`.toBeExtensible fails when not given an extensible object: undefined 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeExtensible(</><dim>)</>
+"expect(received).toBeExtensible()
 
 Expected value to be extensible received:
-  <red>undefined</>"
+  undefined"
 `;

--- a/src/matchers/toBeFalse/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeFalse/__snapshots__/index.test.js.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeFalse fails when given false 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeFalse(</><dim>)</>
+"expect(received).not.toBeFalse()
 
 Expected value to not be false received:
-  <red>false</>"
+  false"
 `;
 
 exports[`.toBeFalse fails when not given false 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeFalse(</><dim>)</>
+"expect(received).toBeFalse()
 
 Expected value to be false:
-  <green>false</>
+  false
 Received:
-  <red>true</>"
+  true"
 `;

--- a/src/matchers/toBeFinite/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeFinite/__snapshots__/index.test.js.snap
@@ -1,22 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeFinite fails when given a finite number 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeFinite(</><dim>)</>
+"expect(received).not.toBeFinite()
 
 Expected value to not be finite received:
-  <red>1</>"
+  1"
 `;
 
 exports[`.toBeFinite fails when not given Infinity 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeFinite(</><dim>)</>
+"expect(received).toBeFinite()
 
 Expected value to be finite received:
-  <red>Infinity</>"
+  Infinity"
 `;
 
 exports[`.toBeFinite fails when not given NaN 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeFinite(</><dim>)</>
+"expect(received).toBeFinite()
 
 Expected value to be finite received:
-  <red>NaN</>"
+  NaN"
 `;

--- a/src/matchers/toBeFrozen/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeFrozen/__snapshots__/index.test.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeFrozen fails when given frozen object 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeFrozen(</><dim>)</>
+"expect(received).not.toBeFrozen()
 
 Expected object to not be frozen"
 `;
 
 exports[`.toBeFrozen fails when given a non-frozen object 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeFrozen(</><dim>)</>
+"expect(received).toBeFrozen()
 
 Expected object to be frozen"
 `;

--- a/src/matchers/toBeFunction/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeFunction/__snapshots__/index.test.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeFunction fails when given a function 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeFunction(</><dim>)</>
+"expect(received).not.toBeFunction()
 
 Expected value to not be a function, received:
-  <red>[Function anonymous]</>"
+  [Function anonymous]"
 `;
 
 exports[`.toBeFunction fails when not given a function 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeFunction(</><dim>)</>
+"expect(received).toBeFunction()
 
 Expected to receive a function, received:
-  <red>false</>"
+  false"
 `;

--- a/src/matchers/toBeHexadecimal/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeHexadecimal/__snapshots__/index.test.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeHexadecimal fails when given valid hexadecimal 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeHexadecimal(</><dim>)</>
+"expect(received).not.toBeHexadecimal()
 
 Expected value to not be a hexadecimal, received:
-  <red>\\"#eeffee\\"</>"
+  \\"#eeffee\\""
 `;
 
 exports[`.toBeHexadecimal fails when given non-string 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeHexadecimal(</><dim>)</>
+"expect(received).toBeHexadecimal()
 
 Expected value to be a hexadecimal, received:
-  <red>true</>"
+  true"
 `;

--- a/src/matchers/toBeNaN/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeNaN/__snapshots__/index.test.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeNaN fails when given a non-number 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeNaN(</><dim>)</>
+"expect(received).not.toBeNaN()
 
 Expected value to be a number received:
-  <red>undefined</>"
+  undefined"
 `;
 
 exports[`.toBeNaN fails when given a number 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeNaN(</><dim>)</>
+"expect(received).toBeNaN()
 
 Expected value to not be a number received:
-  <red>3</>"
+  3"
 `;

--- a/src/matchers/toBeNegative/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeNegative/__snapshots__/index.test.js.snap
@@ -1,22 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeNegative fails when given negative number 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeNegative(</><dim>)</>
+"expect(received).not.toBeNegative()
 
 Expected value to not be a negative number received:
-  <red>-1</>"
+  -1"
 `;
 
 exports[`.toBeNegative fails when given Infinity 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeNegative(</><dim>)</>
+"expect(received).toBeNegative()
 
 Expected value to be a negative number received:
-  <red>Infinity</>"
+  Infinity"
 `;
 
 exports[`.toBeNegative fails when given positive number 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeNegative(</><dim>)</>
+"expect(received).toBeNegative()
 
 Expected value to be a negative number received:
-  <red>1</>"
+  1"
 `;

--- a/src/matchers/toBeNil/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeNil/__snapshots__/index.test.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeNil fails when null is given 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeNil(</><dim>)</>
+"expect(received).not.toBeNil()
 
 Expected value not to be null or undefined, received:
-  <red>null</>"
+  null"
 `;
 
 exports[`.toBeNil fails when the value is not null or undefined 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeNil(</><dim>)</>
+"expect(received).toBeNil()
 
 Expected value to be null or undefined, received:
-  <red>\\"value\\"</>"
+  \\"value\\""
 `;

--- a/src/matchers/toBeNumber/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeNumber/__snapshots__/index.test.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeNumber fails when given a number 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeNumber(</><dim>)</>
+"expect(received).not.toBeNumber()
 
 Expected value to not be a number received:
-  <red>1</>"
+  1"
 `;
 
 exports[`.toBeNumber fails when not given a number 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeNumber(</><dim>)</>
+"expect(received).toBeNumber()
 
 Expected value to be a number received:
-  <red>false</>"
+  false"
 `;

--- a/src/matchers/toBeObject/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeObject/__snapshots__/index.test.js.snap
@@ -1,57 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeObject fails when given an object 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeObject(</><dim>)</>
+"expect(received).not.toBeObject()
 
 Expected value to not be an object, received:
-  <red>{}</>"
+  {}"
 `;
 
 exports[`.toBeObject fails when not given an object:  1`] = `
-"<dim>expect(</><red>received</><dim>).toBeObject(</><dim>)</>
+"expect(received).toBeObject()
 
 Expected value to be an object, received:
-  <red>\\"\\"</>"
+  \\"\\""
 `;
 
 exports[`.toBeObject fails when not given an object: 0 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeObject(</><dim>)</>
+"expect(received).toBeObject()
 
 Expected value to be an object, received:
-  <red>0</>"
+  0"
 `;
 
 exports[`.toBeObject fails when not given an object: 1,2,3 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeObject(</><dim>)</>
+"expect(received).toBeObject()
 
 Expected value to be an object, received:
-  <red>[1, 2, 3]</>"
+  [1, 2, 3]"
 `;
 
 exports[`.toBeObject fails when not given an object: NaN 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeObject(</><dim>)</>
+"expect(received).toBeObject()
 
 Expected value to be an object, received:
-  <red>NaN</>"
+  NaN"
 `;
 
 exports[`.toBeObject fails when not given an object: false 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeObject(</><dim>)</>
+"expect(received).toBeObject()
 
 Expected value to be an object, received:
-  <red>false</>"
+  false"
 `;
 
 exports[`.toBeObject fails when not given an object: undefined 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeObject(</><dim>)</>
+"expect(received).toBeObject()
 
 Expected value to be an object, received:
-  <red>[Function anonymous]</>"
+  [Function anonymous]"
 `;
 
 exports[`.toBeObject fails when not given an object: undefined 2`] = `
-"<dim>expect(</><red>received</><dim>).toBeObject(</><dim>)</>
+"expect(received).toBeObject()
 
 Expected value to be an object, received:
-  <red>undefined</>"
+  undefined"
 `;

--- a/src/matchers/toBeOdd/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeOdd/__snapshots__/index.test.js.snap
@@ -1,71 +1,71 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeOdd fails when given an odd number 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeOdd(</><dim>)</>
+"expect(received).not.toBeOdd()
 
 Expected value to not be odd received:
-  <red>1</>"
+  1"
 `;
 
 exports[`.toBeOdd fails when given not given an odd number 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeOdd(</><dim>)</>
+"expect(received).toBeOdd()
 
 Expected value to be odd received:
-  <red>false</>"
+  false"
 `;
 
 exports[`.toBeOdd fails when given not given an odd number 2`] = `
-"<dim>expect(</><red>received</><dim>).toBeOdd(</><dim>)</>
+"expect(received).toBeOdd()
 
 Expected value to be odd received:
-  <red>true</>"
+  true"
 `;
 
 exports[`.toBeOdd fails when given not given an odd number 3`] = `
-"<dim>expect(</><red>received</><dim>).toBeOdd(</><dim>)</>
+"expect(received).toBeOdd()
 
 Expected value to be odd received:
-  <red>\\"\\"</>"
+  \\"\\""
 `;
 
 exports[`.toBeOdd fails when given not given an odd number 4`] = `
-"<dim>expect(</><red>received</><dim>).toBeOdd(</><dim>)</>
+"expect(received).toBeOdd()
 
 Expected value to be odd received:
-  <red>2</>"
+  2"
 `;
 
 exports[`.toBeOdd fails when given not given an odd number 5`] = `
-"<dim>expect(</><red>received</><dim>).toBeOdd(</><dim>)</>
+"expect(received).toBeOdd()
 
 Expected value to be odd received:
-  <red>{}</>"
+  {}"
 `;
 
 exports[`.toBeOdd fails when given not given an odd number 6`] = `
-"<dim>expect(</><red>received</><dim>).toBeOdd(</><dim>)</>
+"expect(received).toBeOdd()
 
 Expected value to be odd received:
-  <red>[Function anonymous]</>"
+  [Function anonymous]"
 `;
 
 exports[`.toBeOdd fails when given not given an odd number 7`] = `
-"<dim>expect(</><red>received</><dim>).toBeOdd(</><dim>)</>
+"expect(received).toBeOdd()
 
 Expected value to be odd received:
-  <red>undefined</>"
+  undefined"
 `;
 
 exports[`.toBeOdd fails when given not given an odd number 8`] = `
-"<dim>expect(</><red>received</><dim>).toBeOdd(</><dim>)</>
+"expect(received).toBeOdd()
 
 Expected value to be odd received:
-  <red>null</>"
+  null"
 `;
 
 exports[`.toBeOdd fails when given not given an odd number 9`] = `
-"<dim>expect(</><red>received</><dim>).toBeOdd(</><dim>)</>
+"expect(received).toBeOdd()
 
 Expected value to be odd received:
-  <red>NaN</>"
+  NaN"
 `;

--- a/src/matchers/toBeOneOf/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeOneOf/__snapshots__/index.test.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeOneOf fails when value is in given array 1`] = `
-"<dim>expect(</><red>item</><dim>).not.toBeOneOf(</><green>list</><dim>)</>
+"expect(item).not.toBeOneOf(list)
 
 Expected value to not be in list:
-  <green>[1, 2, 3]</>
+  [1, 2, 3]
 Received:
-  <red>1</>"
+  1"
 `;
 
 exports[`.toBeOneOf fails when value is not in given array 1`] = `
-"<dim>expect(</><red>item</><dim>).toBeOneOf(</><green>list</><dim>)</>
+"expect(item).toBeOneOf(list)
 
 Expected value to be in list:
-  <green>[1, 2, 3]</>
+  [1, 2, 3]
 Received:
-  <red>4</>"
+  4"
 `;

--- a/src/matchers/toBePositive/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBePositive/__snapshots__/index.test.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBePositive fails when given a positive number 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBePositive(</><dim>)</>
+"expect(received).not.toBePositive()
 
 Expected value to not be positive received:
-  <red>5</>"
+  5"
 `;
 
 exports[`.toBePositive fails when not given a positive number 1`] = `
-"<dim>expect(</><red>received</><dim>).toBePositive(</><dim>)</>
+"expect(received).toBePositive()
 
 Expected value to be positive received:
-  <red>-1</>"
+  -1"
 `;

--- a/src/matchers/toBeSealed/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeSealed/__snapshots__/index.test.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeSealed fails when given sealed object 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeSealed(</><dim>)</>
+"expect(received).not.toBeSealed()
 
 Expected object to be not sealed"
 `;
 
 exports[`.toBeSealed fails when given a non-sealed object 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeSealed(</><dim>)</>
+"expect(received).toBeSealed()
 
 Expected object to not sealed"
 `;

--- a/src/matchers/toBeString/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeString/__snapshots__/index.test.js.snap
@@ -1,24 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeString fails when given a string literal 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeString(</><dim>)</>
+"expect(received).not.toBeString()
 
 Expected value to not be of type string received:
-  <red>\\"\\"</>"
+  \\"\\""
 `;
 
 exports[`.not.toBeString fails when given an object of type string 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeString(</><dim>)</>
+"expect(received).not.toBeString()
 
 Expected value to not be of type string received:
-  <red>{\\"0\\": \\"s\\", \\"1\\": \\"t\\", \\"10\\": \\"e\\", \\"2\\": \\"r\\", \\"3\\": \\"i\\", \\"4\\": \\"n\\", \\"5\\": \\"g\\", \\"6\\": \\" \\", \\"7\\": \\"t\\", \\"8\\": \\"y\\", \\"9\\": \\"p\\"}</>"
+  {\\"0\\": \\"s\\", \\"1\\": \\"t\\", \\"10\\": \\"e\\", \\"2\\": \\"r\\", \\"3\\": \\"i\\", \\"4\\": \\"n\\", \\"5\\": \\"g\\", \\"6\\": \\" \\", \\"7\\": \\"t\\", \\"8\\": \\"y\\", \\"9\\": \\"p\\"}"
 `;
 
 exports[`.toBeString fails when not given a string 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeString(</><dim>)</>
+"expect(received).toBeString()
 
 Expected value to be of type string:
-  <green>\\"type of string\\"</>
+  \\"type of string\\"
 Received:
-  <red>\\"number\\"</>"
+  \\"number\\""
 `;

--- a/src/matchers/toBeTrue/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeTrue/__snapshots__/index.test.js.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeTrue fails when given true 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeTrue(</><dim>)</>
+"expect(received).not.toBeTrue()
 
 Expected value to not be true received:
-  <red>true</>"
+  true"
 `;
 
 exports[`.toBeTrue fails when not given true 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeTrue(</><dim>)</>
+"expect(received).toBeTrue()
 
 Expected value to be true:
-  <green>true</>
+  true
 Received:
-  <red>false</>"
+  false"
 `;

--- a/src/matchers/toBeValidDate/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeValidDate/__snapshots__/index.test.js.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeValidDate fails when given a valid date value 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeValidDate(</><dim>)</>
+"expect(received).not.toBeValidDate()
 
 Expected value to not be a valid date received:
-  <red>2018-01-01T13:00:00.000Z</>"
+  2018-01-01T13:00:00.000Z"
 `;
 
 exports[`.toBeValidDate fails when given an invalid date 1`] = `"Invalid time value"`;
 
 exports[`.toBeValidDate fails when not given non-date values 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeValidDate(</><dim>)</>
+"expect(received).toBeValidDate()
 
 Expected value to be a valid date received:
-  <red>1</>"
+  1"
 `;

--- a/src/matchers/toBeWithin/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeWithin/__snapshots__/index.test.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeWithin fails when given number is within the given bounds of start (inclusive) and end (exclusive) 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeWithin(</><green>expected</><dim>)</>
+"expect(received).not.toBeWithin(expected)
 
 Expected number to not be within start (inclusive) and end (exclusive):
-  start: <green>1</>  end: <green>3</>
+  start: 1  end: 3
 Received:
-  <red>1</>"
+  1"
 `;
 
 exports[`.toBeWithin fails when given number is not within the given bounds of start (inclusive) and end (exclusive) 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeWithin(</><green>expected</><dim>)</>
+"expect(received).toBeWithin(expected)
 
 Expected number to be within start (inclusive) and end (exclusive):
-  start: <green>1</>  end: <green>3</>
+  start: 1  end: 3
 Received:
-  <red>3</>"
+  3"
 `;

--- a/src/matchers/toContainAllEntries/__snapshots__/index.test.js.snap
+++ b/src/matchers/toContainAllEntries/__snapshots__/index.test.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toContainAllEntries fails when object only contains all of the given entries 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainAllEntries(</><green>expected</><dim>)</>
+"expect(received).not.toContainAllEntries(expected)
 
 Expected object to not only contain all of the given entries:
-  <green>[[\\"b\\", \\"bar\\"], [\\"a\\", \\"foo\\"], [\\"c\\", \\"baz\\"]]</>
+  [[\\"b\\", \\"bar\\"], [\\"a\\", \\"foo\\"], [\\"c\\", \\"baz\\"]]
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
+  {\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}"
 `;
 
 exports[`.toContainAllEntries fails when object does not only contain all of the given entries 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainAllEntries(</><green>expected</><dim>)</>
+"expect(received).toContainAllEntries(expected)
 
 Expected object to only contain all of the given entries:
-  <green>[[\\"a\\", \\"foo\\"], [\\"b\\", \\"bar\\"]]</>
+  [[\\"a\\", \\"foo\\"], [\\"b\\", \\"bar\\"]]
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
+  {\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}"
 `;

--- a/src/matchers/toContainAllKeys/__snapshots__/index.test.js.snap
+++ b/src/matchers/toContainAllKeys/__snapshots__/index.test.js.snap
@@ -1,37 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toContainAllKeys fails when given object contains all keys 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainAllKeys(</><green>expected</><dim>)</>
+"expect(received).not.toContainAllKeys(expected)
 
 Expected object to not contain all keys:
-  <green>[\\"b\\", \\"a\\"]</>
+  [\\"b\\", \\"a\\"]
 Received:
-  <red>[\\"a\\", \\"b\\"]</>"
+  [\\"a\\", \\"b\\"]"
 `;
 
 exports[`.toContainAllKeys fails when all of the object keys are matched, but there are additional keys  1`] = `
-"<dim>expect(</><red>received</><dim>).toContainAllKeys(</><green>expected</><dim>)</>
+"expect(received).toContainAllKeys(expected)
 
 Expected object to contain all keys:
-  <green>[\\"a\\", \\"c\\"]</>
+  [\\"a\\", \\"c\\"]
 Received:
-  <red>[\\"a\\", \\"b\\"]</>"
+  [\\"a\\", \\"b\\"]"
 `;
 
 exports[`.toContainAllKeys fails when given an empty object 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainAllKeys(</><green>expected</><dim>)</>
+"expect(received).toContainAllKeys(expected)
 
 Expected object to contain all keys:
-  <green>[\\"a\\"]</>
+  [\\"a\\"]
 Received:
-  <red>[]</>"
+  []"
 `;
 
 exports[`.toContainAllKeys fails when given object does not contain all keys 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainAllKeys(</><green>expected</><dim>)</>
+"expect(received).toContainAllKeys(expected)
 
 Expected object to contain all keys:
-  <green>[\\"a\\"]</>
+  [\\"a\\"]
 Received:
-  <red>[\\"a\\", \\"b\\"]</>"
+  [\\"a\\", \\"b\\"]"
 `;

--- a/src/matchers/toContainAllValues/__snapshots__/index.test.js.snap
+++ b/src/matchers/toContainAllValues/__snapshots__/index.test.js.snap
@@ -1,64 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toContainAllValues fails when given object contains all values including arrays 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainAllValues(</><green>expected</><dim>)</>
+"expect(received).not.toContainAllValues(expected)
 
 Expected object to not contain all values:
-  <green>[\\"duck\\", [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]]</>
+  [\\"duck\\", [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]]
 Received:
-  <red>{\\"donald\\": \\"duck\\", \\"message\\": [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]}</>"
+  {\\"donald\\": \\"duck\\", \\"message\\": [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]}"
 `;
 
 exports[`.not.toContainAllValues fails when given object contains all values including objects 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainAllValues(</><green>expected</><dim>)</>
+"expect(received).not.toContainAllValues(expected)
 
 Expected object to not contain all values:
-  <green>[{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}, \\"duck\\"]</>
+  [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}, \\"duck\\"]
 Received:
-  <red>{\\"donald\\": \\"duck\\", \\"message\\": {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}}</>"
+  {\\"donald\\": \\"duck\\", \\"message\\": {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}}"
 `;
 
 exports[`.not.toContainAllValues fails when given object contains primitive values 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainAllValues(</><green>expected</><dim>)</>
+"expect(received).not.toContainAllValues(expected)
 
 Expected object to not contain all values:
-  <green>[\\"world\\", 0, false]</>
+  [\\"world\\", 0, false]
 Received:
-  <red>{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}</>"
+  {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}"
 `;
 
 exports[`.toContainAllValues fails when given object does not contain all primitive values 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainAllValues(</><green>expected</><dim>)</>
+"expect(received).toContainAllValues(expected)
 
 Expected object to contain all values:
-  <green>[\\"hello\\", 0, false]</>
+  [\\"hello\\", 0, false]
 Received:
-  <red>{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}</>"
+  {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}"
 `;
 
 exports[`.toContainAllValues fails when given object does not contain all primitive values 2`] = `
-"<dim>expect(</><red>received</><dim>).toContainAllValues(</><green>expected</><dim>)</>
+"expect(received).toContainAllValues(expected)
 
 Expected object to contain all values:
-  <green>[\\"world\\", 0]</>
+  [\\"world\\", 0]
 Received:
-  <red>{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}</>"
+  {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}"
 `;
 
 exports[`.toContainAllValues fails when given object does not contain all values including arrays 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainAllValues(</><green>expected</><dim>)</>
+"expect(received).toContainAllValues(expected)
 
 Expected object to contain all values:
-  <green>[\\"duck\\", [{\\"hello\\": \\"world\\"}]]</>
+  [\\"duck\\", [{\\"hello\\": \\"world\\"}]]
 Received:
-  <red>{\\"donald\\": \\"duck\\", \\"message\\": [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]}</>"
+  {\\"donald\\": \\"duck\\", \\"message\\": [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]}"
 `;
 
 exports[`.toContainAllValues fails when given object does not contain all values including objects 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainAllValues(</><green>expected</><dim>)</>
+"expect(received).toContainAllValues(expected)
 
 Expected object to contain all values:
-  <green>[{\\"hello\\": \\"world\\"}]</>
+  [{\\"hello\\": \\"world\\"}]
 Received:
-  <red>{\\"donald\\": \\"duck\\", \\"message\\": {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}}</>"
+  {\\"donald\\": \\"duck\\", \\"message\\": {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}}"
 `;

--- a/src/matchers/toContainAnyEntries/__snapshots__/index.test.js.snap
+++ b/src/matchers/toContainAnyEntries/__snapshots__/index.test.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toContainAnyEntries fails when given object contains atleast one of the given entries 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainAnyEntries(</><green>expected</><dim>)</>
+"expect(received).not.toContainAnyEntries(expected)
 
 Expected object to not contain any of the provided entries:
-  <green>[[\\"a\\", \\"qux\\"], [\\"a\\", \\"foo\\"]]</>
+  [[\\"a\\", \\"qux\\"], [\\"a\\", \\"foo\\"]]
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
+  {\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}"
 `;
 
 exports[`.toContainAnyEntries fails when given object does not contain any of the given entries 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainAnyEntries(</><green>expected</><dim>)</>
+"expect(received).toContainAnyEntries(expected)
 
 Expected object to contain any of the provided entries:
-  <green>[[\\"a\\", \\"qux\\"], [\\"b\\", \\"foo\\"]]</>
+  [[\\"a\\", \\"qux\\"], [\\"b\\", \\"foo\\"]]
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
+  {\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}"
 `;

--- a/src/matchers/toContainAnyKeys/__snapshots__/index.test.js.snap
+++ b/src/matchers/toContainAnyKeys/__snapshots__/index.test.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toContainAnyKeys fails when object contains one or more keys 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainAnyKeys(</><green>expected</><dim>)</>
+"expect(received).not.toContainAnyKeys(expected)
 
 Expected object not to contain any of the following keys:
-  <green>[\\"name\\", \\"age\\"]</>
+  [\\"name\\", \\"age\\"]
 Received:
-  <red>{\\"age\\": 37, \\"name\\": \\"Steve the Pirate\\"}</>"
+  {\\"age\\": 37, \\"name\\": \\"Steve the Pirate\\"}"
 `;
 
 exports[`.toContainAnyKeys fails when object does not contain any keys 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainValue(</><green>expected</><dim>)</>
+"expect(received).toContainValue(expected)
 
 Expected object to contain any of the following keys:
-  <green>[\\"occupation\\"]</>
+  [\\"occupation\\"]
 Received:
-  <red>{\\"age\\": 37, \\"name\\": \\"Steve the Pirate\\"}</>"
+  {\\"age\\": 37, \\"name\\": \\"Steve the Pirate\\"}"
 `;

--- a/src/matchers/toContainAnyValues/__snapshots__/index.test.js.snap
+++ b/src/matchers/toContainAnyValues/__snapshots__/index.test.js.snap
@@ -1,46 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toContainAnyValues fails when given object contains value 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainAnyValues(</><green>expected</><dim>)</>
+"expect(received).not.toContainAnyValues(expected)
 
 Expected object to not contain any of the following values:
-  <green>[\\"baz\\"]</>
+  [\\"baz\\"]
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
+  {\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}"
 `;
 
 exports[`.not.toContainAnyValues fails when given object contains value 2`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainAnyValues(</><green>expected</><dim>)</>
+"expect(received).not.toContainAnyValues(expected)
 
 Expected object to not contain any of the following values:
-  <green>[\\"foo\\", \\"bar\\"]</>
+  [\\"foo\\", \\"bar\\"]
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
+  {\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}"
 `;
 
 exports[`.toContainAnyValues fails when given object does not contain value 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainAnyValues(</><green>expected</><dim>)</>
+"expect(received).toContainAnyValues(expected)
 
 Expected object to contain any of the following values:
-  <green>[\\"fax\\"]</>
+  [\\"fax\\"]
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
+  {\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}"
 `;
 
 exports[`.toContainAnyValues fails when given object does not contain value 2`] = `
-"<dim>expect(</><red>received</><dim>).toContainAnyValues(</><green>expected</><dim>)</>
+"expect(received).toContainAnyValues(expected)
 
 Expected object to contain any of the following values:
-  <green>[\\"fax\\", \\"rom\\"]</>
+  [\\"fax\\", \\"rom\\"]
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
+  {\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}"
 `;
 
 exports[`.toContainAnyValues fails when given object does not contain value 3`] = `
-"<dim>expect(</><red>received</><dim>).toContainAnyValues(</><green>expected</><dim>)</>
+"expect(received).toContainAnyValues(expected)
 
 Expected object to contain any of the following values:
-  <green>[\\"dae\\", \\"mur\\", \\"zoe\\"]</>
+  [\\"dae\\", \\"mur\\", \\"zoe\\"]
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
+  {\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}"
 `;

--- a/src/matchers/toContainEntries/__snapshots__/index.test.js.snap
+++ b/src/matchers/toContainEntries/__snapshots__/index.test.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toContainEntries fails when object contains all of the given entries 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainEntries(</><green>expected</><dim>)</>
+"expect(received).not.toContainEntries(expected)
 
 Expected object to not contain all of the given entries:
-  <green>[[\\"b\\", \\"bar\\"], [\\"c\\", \\"baz\\"]]</>
+  [[\\"b\\", \\"bar\\"], [\\"c\\", \\"baz\\"]]
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
+  {\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}"
 `;
 
 exports[`.toContainEntries fails when object does not contain all of the given entries 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainEntries(</><green>expected</><dim>)</>
+"expect(received).toContainEntries(expected)
 
 Expected object to contain all of the given entries:
-  <green>[\\"b\\", \\"foo\\"]</>
+  [\\"b\\", \\"foo\\"]
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
+  {\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}"
 `;

--- a/src/matchers/toContainEntry/__snapshots__/index.test.js.snap
+++ b/src/matchers/toContainEntry/__snapshots__/index.test.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toContainEntry fails when object contains given entry 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainEntry(</><green>expected</><dim>)</>
+"expect(received).not.toContainEntry(expected)
 
 Expected object to not contain entry:
-  <green>[\\"b\\", \\"bar\\"]</>
+  [\\"b\\", \\"bar\\"]
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
+  {\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}"
 `;
 
 exports[`.toContainEntry fails when object does not contain given entry 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainEntry(</><green>expected</><dim>)</>
+"expect(received).toContainEntry(expected)
 
 Expected object to contain entry:
-  <green>[\\"b\\", \\"foo\\"]</>
+  [\\"b\\", \\"foo\\"]
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
+  {\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}"
 `;

--- a/src/matchers/toContainKey/__snapshots__/index.test.js.snap
+++ b/src/matchers/toContainKey/__snapshots__/index.test.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toContainKey fails when given object contains key 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainKey(</><green>expected</><dim>)</>
+"expect(received).not.toContainKey(expected)
 
 Expected object to not contain key:
-  <green>\\"hello\\"</>
+  \\"hello\\"
 Received:
-  <red>{\\"hello\\": \\"world\\"}</>"
+  {\\"hello\\": \\"world\\"}"
 `;
 
 exports[`.toContainKey fails when given object does not contain key 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainKey(</><green>expected</><dim>)</>
+"expect(received).toContainKey(expected)
 
 Expected object to contain key:
-  <green>\\"missing\\"</>
+  \\"missing\\"
 Received:
-  <red>{\\"hello\\": \\"world\\"}</>"
+  {\\"hello\\": \\"world\\"}"
 `;

--- a/src/matchers/toContainKeys/__snapshots__/index.test.js.snap
+++ b/src/matchers/toContainKeys/__snapshots__/index.test.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toContainKeys fails when object contains all keys 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainKeys(</><green>expected</><dim>)</>
+"expect(received).not.toContainKeys(expected)
 
 Expected object to not contain all keys:
-  <green>[\\"a\\", \\"b\\", \\"c\\"]</>
+  [\\"a\\", \\"b\\", \\"c\\"]
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
+  {\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}"
 `;
 
 exports[`.toContainKeys fails when object does not contain all keys 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainKeys(</><green>expected</><dim>)</>
+"expect(received).toContainKeys(expected)
 
 Expected object to contain all keys:
-  <green>[\\"a\\", \\"d\\"]</>
+  [\\"a\\", \\"d\\"]
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
+  {\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}"
 `;

--- a/src/matchers/toContainValue/__snapshots__/index.test.js.snap
+++ b/src/matchers/toContainValue/__snapshots__/index.test.js.snap
@@ -1,55 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toContainValue fails when given object contains array value 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainValue(</><green>expected</><dim>)</>
+"expect(received).not.toContainValue(expected)
 
 Expected object to not contain value:
-  <green>[{\\"hello\\": \\"world\\"}]</>
+  [{\\"hello\\": \\"world\\"}]
 Received:
-  <red>{\\"message\\": [{\\"hello\\": \\"world\\"}]}</>"
+  {\\"message\\": [{\\"hello\\": \\"world\\"}]}"
 `;
 
 exports[`.not.toContainValue fails when given object contains object value 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainValue(</><green>expected</><dim>)</>
+"expect(received).not.toContainValue(expected)
 
 Expected object to not contain value:
-  <green>{\\"hello\\": \\"world\\"}</>
+  {\\"hello\\": \\"world\\"}
 Received:
-  <red>{\\"message\\": {\\"hello\\": \\"world\\"}}</>"
+  {\\"message\\": {\\"hello\\": \\"world\\"}}"
 `;
 
 exports[`.not.toContainValue fails when given object contains primitive value 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainValue(</><green>expected</><dim>)</>
+"expect(received).not.toContainValue(expected)
 
 Expected object to not contain value:
-  <green>\\"world\\"</>
+  \\"world\\"
 Received:
-  <red>{\\"hello\\": \\"world\\"}</>"
+  {\\"hello\\": \\"world\\"}"
 `;
 
 exports[`.toContainValue fails when given object does not contain array value 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainValue(</><green>expected</><dim>)</>
+"expect(received).toContainValue(expected)
 
 Expected object to contain value:
-  <green>[{\\"world\\": \\"hello\\"}]</>
+  [{\\"world\\": \\"hello\\"}]
 Received:
-  <red>{\\"message\\": [{\\"hello\\": \\"world\\"}]}</>"
+  {\\"message\\": [{\\"hello\\": \\"world\\"}]}"
 `;
 
 exports[`.toContainValue fails when given object does not contain object value 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainValue(</><green>expected</><dim>)</>
+"expect(received).toContainValue(expected)
 
 Expected object to contain value:
-  <green>{\\"world\\": \\"hello\\"}</>
+  {\\"world\\": \\"hello\\"}
 Received:
-  <red>{\\"message\\": {\\"hello\\": \\"world\\"}}</>"
+  {\\"message\\": {\\"hello\\": \\"world\\"}}"
 `;
 
 exports[`.toContainValue fails when given object does not contain primitive value 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainValue(</><green>expected</><dim>)</>
+"expect(received).toContainValue(expected)
 
 Expected object to contain value:
-  <green>\\"hello\\"</>
+  \\"hello\\"
 Received:
-  <red>{\\"hello\\": \\"world\\"}</>"
+  {\\"hello\\": \\"world\\"}"
 `;

--- a/src/matchers/toContainValues/__snapshots__/index.test.js.snap
+++ b/src/matchers/toContainValues/__snapshots__/index.test.js.snap
@@ -1,55 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toContainValues fails when given object contains all values including arrays 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainValues(</><green>expected</><dim>)</>
+"expect(received).not.toContainValues(expected)
 
 Expected object to not contain all values:
-  <green>[\\"duck\\", [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]]</>
+  [\\"duck\\", [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]]
 Received:
-  <red>{\\"donald\\": \\"duck\\", \\"message\\": [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]}</>"
+  {\\"donald\\": \\"duck\\", \\"message\\": [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]}"
 `;
 
 exports[`.not.toContainValues fails when given object contains all values including objects 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainValues(</><green>expected</><dim>)</>
+"expect(received).not.toContainValues(expected)
 
 Expected object to not contain all values:
-  <green>[{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}, \\"duck\\"]</>
+  [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}, \\"duck\\"]
 Received:
-  <red>{\\"donald\\": \\"duck\\", \\"message\\": {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}}</>"
+  {\\"donald\\": \\"duck\\", \\"message\\": {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}}"
 `;
 
 exports[`.not.toContainValues fails when given object contains primitive values 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainValues(</><green>expected</><dim>)</>
+"expect(received).not.toContainValues(expected)
 
 Expected object to not contain all values:
-  <green>[\\"world\\", false]</>
+  [\\"world\\", false]
 Received:
-  <red>{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}</>"
+  {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}"
 `;
 
 exports[`.toContainValues fails when given object does not contain all primitive values 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainValues(</><green>expected</><dim>)</>
+"expect(received).toContainValues(expected)
 
 Expected object to contain all values:
-  <green>[\\"hello\\", 0, false]</>
+  [\\"hello\\", 0, false]
 Received:
-  <red>{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}</>"
+  {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}"
 `;
 
 exports[`.toContainValues fails when given object does not contain all values including arrays 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainValues(</><green>expected</><dim>)</>
+"expect(received).toContainValues(expected)
 
 Expected object to contain all values:
-  <green>[\\"duck\\", [{\\"hello\\": \\"world\\"}]]</>
+  [\\"duck\\", [{\\"hello\\": \\"world\\"}]]
 Received:
-  <red>{\\"donald\\": \\"duck\\", \\"message\\": [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]}</>"
+  {\\"donald\\": \\"duck\\", \\"message\\": [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]}"
 `;
 
 exports[`.toContainValues fails when given object does not contain all values including objects 1`] = `
-"<dim>expect(</><red>received</><dim>).toContainValues(</><green>expected</><dim>)</>
+"expect(received).toContainValues(expected)
 
 Expected object to contain all values:
-  <green>[{\\"hello\\": \\"world\\"}]</>
+  [{\\"hello\\": \\"world\\"}]
 Received:
-  <red>{\\"donald\\": \\"duck\\", \\"message\\": {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}}</>"
+  {\\"donald\\": \\"duck\\", \\"message\\": {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}}"
 `;

--- a/src/matchers/toEndWith/__snapshots__/index.test.js.snap
+++ b/src/matchers/toEndWith/__snapshots__/index.test.js.snap
@@ -1,28 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toEndWith fails when string ends with given suffix 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toEndWith(</><green>expected</><dim>)</>
+"expect(received).not.toEndWith(expected)
 
 Expected string to not end with:
-  <green>\\"world\\"</>
+  \\"world\\"
 Received:
-  <red>\\"hello world\\"</>"
+  \\"hello world\\""
 `;
 
 exports[`.toEndWith fails when string does not end with the given suffix 1`] = `
-"<dim>expect(</><red>received</><dim>).toEndWith(</><green>expected</><dim>)</>
+"expect(received).toEndWith(expected)
 
 Expected string to end with:
-  <green>\\"hello\\"</>
+  \\"hello\\"
 Received:
-  <red>\\"hello world\\"</>"
+  \\"hello world\\""
 `;
 
 exports[`.toEndWith fails when the string is shorter than the given suffix 1`] = `
-"<dim>expect(</><red>received</><dim>).toEndWith(</><green>expected</><dim>)</>
+"expect(received).toEndWith(expected)
 
 Expected string to end with:
-  <green>\\"hello world\\"</>
+  \\"hello world\\"
 Received:
-  <red>\\"hello\\"</>"
+  \\"hello\\""
 `;

--- a/src/matchers/toEqualCaseInsensitive/__snapshots__/index.test.js.snap
+++ b/src/matchers/toEqualCaseInsensitive/__snapshots__/index.test.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toEqualCaseInsensitive fails if strings do not match 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toEqualCaseInsensitive(</><green>expected</><dim>)</>
+"expect(received).not.toEqualCaseInsensitive(expected)
 
 Expected values to not be equal while ignoring case (using ===):
-  <green>\\"aaaa\\"</>
+  \\"aaaa\\"
 Received:
-  <red>\\"aaaa\\"</>"
+  \\"aaaa\\""
 `;
 
 exports[`.toEqualCaseInsensitive passes if strings are equal despite case 1`] = `
-"<dim>expect(</><red>received</><dim>).toEqualCaseInsensitive(</><green>expected</><dim>)</>
+"expect(received).toEqualCaseInsensitive(expected)
 
 Expected values to be equal while ignoring case (using ===):
-  <green>\\"bbbb\\"</>
+  \\"bbbb\\"
 Received:
-  <red>\\"aaaa\\"</>"
+  \\"aaaa\\""
 `;

--- a/src/matchers/toHaveBeenCalledAfter/__snapshots__/index.test.js.snap
+++ b/src/matchers/toHaveBeenCalledAfter/__snapshots__/index.test.js.snap
@@ -1,55 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toHaveBeenCalledAfter fails when given a first mock has not been called 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toHaveBeenCalledAfter(</><green>expected</><dim>)</>
+"expect(received).not.toHaveBeenCalledAfter(expected)
 
 Expected first mock to not have been called after, invocationCallOrder:
-  <green>[]</>
+  []
 Received second mock with invocationCallOrder:
-  <red>[]</>"
+  []"
 `;
 
 exports[`.not.toHaveBeenCalledAfter fails when given first mock is called after second mock 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toHaveBeenCalledAfter(</><green>expected</><dim>)</>
+"expect(received).not.toHaveBeenCalledAfter(expected)
 
 Expected first mock to not have been called after, invocationCallOrder:
-  <green>[19]</>
+  [19]
 Received second mock with invocationCallOrder:
-  <red>[18]</>"
+  [18]"
 `;
 
 exports[`.not.toHaveBeenCalledAfter fails when given first mock is called after several calls to second mock 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toHaveBeenCalledAfter(</><green>expected</><dim>)</>
+"expect(received).not.toHaveBeenCalledAfter(expected)
 
 Expected first mock to not have been called after, invocationCallOrder:
-  <green>[26, 27, 28]</>
+  [26, 27, 28]
 Received second mock with invocationCallOrder:
-  <red>[25]</>"
+  [25]"
 `;
 
 exports[`.toHaveBeenCalledAfter fails when given first mock is called before multiple calls to second mock 1`] = `
-"<dim>expect(</><red>received</><dim>).toHaveBeenCalledAfter(</><green>expected</><dim>)</>
+"expect(received).toHaveBeenCalledAfter(expected)
 
 Expected first mock to have been called after, invocationCallOrder:
-  <green>[6, 8]</>
+  [6, 8]
 Received second mock with invocationCallOrder:
-  <red>[7, 9, 10]</>"
+  [7, 9, 10]"
 `;
 
 exports[`.toHaveBeenCalledAfter fails when given first mock that has been called and a second mock that has not been called 1`] = `
-"<dim>expect(</><red>received</><dim>).toHaveBeenCalledAfter(</><green>expected</><dim>)</>
+"expect(received).toHaveBeenCalledAfter(expected)
 
 Expected first mock to have been called after, invocationCallOrder:
-  <green>[1]</>
+  [1]
 Received second mock with invocationCallOrder:
-  <red>[]</>"
+  []"
 `;
 
 exports[`.toHaveBeenCalledAfter fails when given second mock is called after first mock 1`] = `
-"<dim>expect(</><red>received</><dim>).toHaveBeenCalledAfter(</><green>expected</><dim>)</>
+"expect(received).toHaveBeenCalledAfter(expected)
 
 Expected first mock to have been called after, invocationCallOrder:
-  <green>[4000]</>
+  [4000]
 Received second mock with invocationCallOrder:
-  <red>[5000]</>"
+  [5000]"
 `;

--- a/src/matchers/toHaveBeenCalledBefore/__snapshots__/index.test.js.snap
+++ b/src/matchers/toHaveBeenCalledBefore/__snapshots__/index.test.js.snap
@@ -1,55 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toHaveBeenCalledBefore fails when given first mock is called before multiple calls to second mock 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toHaveBeenCalledBefore(</><green>expected</><dim>)</>
+"expect(received).not.toHaveBeenCalledBefore(expected)
 
 Expected first mock to not have been called before, invocationCallOrder:
-  <green>[4000, 6000]</>
+  [4000, 6000]
 Received second mock with invocationCallOrder:
-  <red>[5000, 7000, 8000]</>"
+  [5000, 7000, 8000]"
 `;
 
 exports[`.not.toHaveBeenCalledBefore fails when given first mock is called before second mock 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toHaveBeenCalledBefore(</><green>expected</><dim>)</>
+"expect(received).not.toHaveBeenCalledBefore(expected)
 
 Expected first mock to not have been called before, invocationCallOrder:
-  <green>[4000]</>
+  [4000]
 Received second mock with invocationCallOrder:
-  <red>[5000]</>"
+  [5000]"
 `;
 
 exports[`.not.toHaveBeenCalledBefore fails when given first mock that has been called and a second mock that has not been called 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toHaveBeenCalledBefore(</><green>expected</><dim>)</>
+"expect(received).not.toHaveBeenCalledBefore(expected)
 
 Expected first mock to not have been called before, invocationCallOrder:
-  <green>[4000]</>
+  [4000]
 Received second mock with invocationCallOrder:
-  <red>[]</>"
+  []"
 `;
 
 exports[`.toHaveBeenCalledBefore fails when given a first mock has not been called 1`] = `
-"<dim>expect(</><red>received</><dim>).toHaveBeenCalledBefore(</><green>expected</><dim>)</>
+"expect(received).toHaveBeenCalledBefore(expected)
 
 Expected first mock to have been called before, invocationCallOrder:
-  <green>[]</>
+  []
 Received second mock with invocationCallOrder:
-  <red>[]</>"
+  []"
 `;
 
 exports[`.toHaveBeenCalledBefore fails when given first mock is called after second mock 1`] = `
-"<dim>expect(</><red>received</><dim>).toHaveBeenCalledBefore(</><green>expected</><dim>)</>
+"expect(received).toHaveBeenCalledBefore(expected)
 
 Expected first mock to have been called before, invocationCallOrder:
-  <green>[5000]</>
+  [5000]
 Received second mock with invocationCallOrder:
-  <red>[4000]</>"
+  [4000]"
 `;
 
 exports[`.toHaveBeenCalledBefore fails when given first mock is called after several calls to second mock 1`] = `
-"<dim>expect(</><red>received</><dim>).toHaveBeenCalledBefore(</><green>expected</><dim>)</>
+"expect(received).toHaveBeenCalledBefore(expected)
 
 Expected first mock to have been called before, invocationCallOrder:
-  <green>[5000, 6000, 7000]</>
+  [5000, 6000, 7000]
 Received second mock with invocationCallOrder:
-  <red>[4000]</>"
+  [4000]"
 `;

--- a/src/matchers/toInclude/__snapshots__/index.test.js.snap
+++ b/src/matchers/toInclude/__snapshots__/index.test.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.toInclude .not.toInclude fails when a string does have a given substring 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toInclude(</><green>expected</><dim>)</>
+"expect(received).not.toInclude(expected)
 
 Expected string to not include:
-  <green>\\"ell\\"</>
+  \\"ell\\"
 Received:
-  <red>\\"hello world\\"</>"
+  \\"hello world\\""
 `;
 
 exports[`.toInclude fails when a string does not have a given substring 1`] = `
-"<dim>expect(</><red>received</><dim>).toInclude(</><green>expected</><dim>)</>
+"expect(received).toInclude(expected)
 
 Expected string to include:
-  <green>\\"bob\\"</>
+  \\"bob\\"
 Received:
-  <red>\\"hello world\\"</>"
+  \\"hello world\\""
 `;

--- a/src/matchers/toIncludeAllMembers/__snapshots__/index.test.js.snap
+++ b/src/matchers/toIncludeAllMembers/__snapshots__/index.test.js.snap
@@ -1,37 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toIncludeAllMembers fails when array values matches the members of the set 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toIncludeAllMembers(</><green>expected</><dim>)</>
+"expect(received).not.toIncludeAllMembers(expected)
 
 Expected list to not have all of the following members:
-  <green>[2, 1, 3]</>
+  [2, 1, 3]
 Received:
-  <red>[1, 2, 3]</>"
+  [1, 2, 3]"
 `;
 
 exports[`.toIncludeAllMembers fails when array values do not contain any of the members of the set 1`] = `
-"<dim>expect(</><red>received</><dim>).toIncludeAllMembers(</><green>expected</><dim>)</>
+"expect(received).toIncludeAllMembers(expected)
 
 Expected list to have all of the following members:
-  <green>[1, 2, 3]</>
+  [1, 2, 3]
 Received:
-  <red>[4, 5, 6]</>"
+  [4, 5, 6]"
 `;
 
 exports[`.toIncludeAllMembers fails when expected object is not an array 1`] = `
-"<dim>expect(</><red>received</><dim>).toIncludeAllMembers(</><green>expected</><dim>)</>
+"expect(received).toIncludeAllMembers(expected)
 
 Expected list to have all of the following members:
-  <green>2</>
+  2
 Received:
-  <red>[1, 2, 3]</>"
+  [1, 2, 3]"
 `;
 
 exports[`.toIncludeAllMembers fails when given object is not an array 1`] = `
-"<dim>expect(</><red>received</><dim>).toIncludeAllMembers(</><green>expected</><dim>)</>
+"expect(received).toIncludeAllMembers(expected)
 
 Expected list to have all of the following members:
-  <green>[1, 2, 3]</>
+  [1, 2, 3]
 Received:
-  <red>2</>"
+  2"
 `;

--- a/src/matchers/toIncludeAnyMembers/__snapshots__/index.test.js.snap
+++ b/src/matchers/toIncludeAnyMembers/__snapshots__/index.test.js.snap
@@ -1,55 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toIncludeAnyMembers fails when given array contains array value 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toIncludeAnyMembers(</><green>expected</><dim>)</>
+"expect(received).not.toIncludeAnyMembers(expected)
 
 Expected list to not include any of the following members:
-  <green>[[{\\"hello\\": \\"world\\"}], 7]</>
+  [[{\\"hello\\": \\"world\\"}], 7]
 Received:
-  <red>[[{\\"hello\\": \\"world\\"}]]</>"
+  [[{\\"hello\\": \\"world\\"}]]"
 `;
 
 exports[`.not.toIncludeAnyMembers fails when given array contains object value 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toIncludeAnyMembers(</><green>expected</><dim>)</>
+"expect(received).not.toIncludeAnyMembers(expected)
 
 Expected list to not include any of the following members:
-  <green>[{\\"foo\\": \\"bar\\"}]</>
+  [{\\"foo\\": \\"bar\\"}]
 Received:
-  <red>[{\\"foo\\": \\"bar\\"}]</>"
+  [{\\"foo\\": \\"bar\\"}]"
 `;
 
 exports[`.not.toIncludeAnyMembers fails when given object contains primitive value 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toIncludeAnyMembers(</><green>expected</><dim>)</>
+"expect(received).not.toIncludeAnyMembers(expected)
 
 Expected list to not include any of the following members:
-  <green>[7, 8]</>
+  [7, 8]
 Received:
-  <red>[7]</>"
+  [7]"
 `;
 
 exports[`.toIncludeAnyMembers fails when expected object does not contain array value 1`] = `
-"<dim>expect(</><red>received</><dim>).toIncludeAnyMembers(</><green>expected</><dim>)</>
+"expect(received).toIncludeAnyMembers(expected)
 
 Expected list to include any of the following members:
-  <green>\\"world\\"</>
+  \\"world\\"
 Received:
-  <red>[1, 2, 3]</>"
+  [1, 2, 3]"
 `;
 
 exports[`.toIncludeAnyMembers fails when given array does not contain any members  1`] = `
-"<dim>expect(</><red>received</><dim>).toIncludeAnyMembers(</><green>expected</><dim>)</>
+"expect(received).toIncludeAnyMembers(expected)
 
 Expected list to include any of the following members:
-  <green>[1, 2, 3]</>
+  [1, 2, 3]
 Received:
-  <red>[4, 5, 6]</>"
+  [4, 5, 6]"
 `;
 
 exports[`.toIncludeAnyMembers fails when given object is not an array 1`] = `
-"<dim>expect(</><red>received</><dim>).toIncludeAnyMembers(</><green>expected</><dim>)</>
+"expect(received).toIncludeAnyMembers(expected)
 
 Expected list to include any of the following members:
-  <green>[1, 2, 3]</>
+  [1, 2, 3]
 Received:
-  <red>7</>"
+  7"
 `;

--- a/src/matchers/toIncludeMultiple/__snapshots__/index.test.js.snap
+++ b/src/matchers/toIncludeMultiple/__snapshots__/index.test.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toIncludeMultiple fails when string includes all substrings 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toIncludeMultiple(</><green>expected</><dim>)</>
+"expect(received).not.toIncludeMultiple(expected)
 
 Expected string to not contain all substrings: 
-  <green>[\\"hello\\", \\"world\\"]</>
+  [\\"hello\\", \\"world\\"]
 Received: 
-  <red>\\"hello world\\"</>"
+  \\"hello world\\""
 `;
 
 exports[`.toIncludeMultiple fails when string does not include all substrings 1`] = `
-"<dim>expect(</><red>received</><dim>).toIncludeMultiple(</><green>expected</><dim>)</>
+"expect(received).toIncludeMultiple(expected)
 
 Expected string to contain all substrings: 
-  <green>[\\"hello\\", \\"world\\", \\"bob\\"]</>
+  [\\"hello\\", \\"world\\", \\"bob\\"]
 Received:
-  <red>\\"hello world\\"</>"
+  \\"hello world\\""
 `;

--- a/src/matchers/toIncludeRepeated/__snapshots__/index.test.js.snap
+++ b/src/matchers/toIncludeRepeated/__snapshots__/index.test.js.snap
@@ -1,37 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toIncludeRepeated fails when given string includes given substring 1 time 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toIncludeRepeated(</><green>expected</><dim>)</>
+"expect(received).not.toIncludeRepeated(expected)
 
 Expected string to not include repeated 1 times:
-  <green>\\"ell\\"</>
+  \\"ell\\"
 Received:
-  <red>\\"hello world\\"</>"
+  \\"hello world\\""
 `;
 
 exports[`.not.toIncludeRepeated fails when given string includes given substring to the given occurrences 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toIncludeRepeated(</><green>expected</><dim>)</>
+"expect(received).not.toIncludeRepeated(expected)
 
 Expected string to not include repeated 3 times:
-  <green>\\"l\\"</>
+  \\"l\\"
 Received:
-  <red>\\"hello world\\"</>"
+  \\"hello world\\""
 `;
 
 exports[`.toIncludeRepeated fails when given string does not have a given substring the correct number of times 1`] = `
-"<dim>expect(</><red>received</><dim>).toIncludeRepeated(</><green>expected</><dim>)</>
+"expect(received).toIncludeRepeated(expected)
 
 Expected string to include repeated 2 times:
-  <green>\\"world\\"</>
+  \\"world\\"
 Received:
-  <red>\\"hello world\\"</>"
+  \\"hello world\\""
 `;
 
 exports[`.toIncludeRepeated fails when given string does not include given substring 1`] = `
-"<dim>expect(</><red>received</><dim>).toIncludeRepeated(</><green>expected</><dim>)</>
+"expect(received).toIncludeRepeated(expected)
 
 Expected string to include repeated 1 times:
-  <green>\\"bob\\"</>
+  \\"bob\\"
 Received:
-  <red>\\"hello world\\"</>"
+  \\"hello world\\""
 `;

--- a/src/matchers/toIncludeSameMembers/__snapshots__/index.test.js.snap
+++ b/src/matchers/toIncludeSameMembers/__snapshots__/index.test.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toIncludeSameMembers fails when array contents match 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toIncludeSameMembers(</><green>expected</><dim>)</>
+"expect(received).not.toIncludeSameMembers(expected)
 
 Expected list to not exactly match the members of:
-  <green>[1]</>
+  [1]
 Received:
-  <red>[1]</>"
+  [1]"
 `;
 
 exports[`.toIncludeSameMembers fails when the arrays are not equal in length 1`] = `
-"<dim>expect(</><red>received</><dim>).toIncludeSameMembers(</><green>expected</><dim>)</>
+"expect(received).toIncludeSameMembers(expected)
 
 Expected list to have the following members and no more:
-  <green>[1]</>
+  [1]
 Received:
-  <red>[1, 2]</>"
+  [1, 2]"
 `;

--- a/src/matchers/toReject/__snapshots__/index.test.js.snap
+++ b/src/matchers/toReject/__snapshots__/index.test.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toReject fails when passed a promise that rejects 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toReject(</><dim>)</>
+"expect(received).not.toReject()
 
 Expected promise to resolve, however it rejected.
 "
 `;
 
 exports[`.toReject fails when passed a promise that resolved 1`] = `
-"<dim>expect(</><red>received</><dim>).toReject(</><dim>)</>
+"expect(received).toReject()
 
 Expected promise to reject, however it resolved.
 "

--- a/src/matchers/toResolve/__snapshots__/index.test.js.snap
+++ b/src/matchers/toResolve/__snapshots__/index.test.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toResolve fails when passed a promise that resolved 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toResolve(</><dim>)</>
+"expect(received).not.toResolve()
 
 Expected promise to reject, however it resolved.
 "
 `;
 
 exports[`.toResolve fails when passed a promise that rejects 1`] = `
-"<dim>expect(</><red>received</><dim>).toResolve(</><dim>)</>
+"expect(received).toResolve()
 
 Expected promise to resolve, however it rejected.
 "

--- a/src/matchers/toSatisfy/__snapshots__/index.test.js.snap
+++ b/src/matchers/toSatisfy/__snapshots__/index.test.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toSatisfy fails when given a function that returns true 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toSatisfy(</><dim>)</>
+"expect(received).not.toSatisfy()
 
 Expected value to not satisfy:
-  <green>[Function isTrue]</>
+  [Function isTrue]
 Received:
-  <red>true</>"
+  true"
 `;
 
 exports[`.toSatisfy fails when given function that returns false 1`] = `
-"<dim>expect(</><red>received</><dim>).toSatisfy(</><dim>)</>
+"expect(received).toSatisfy()
 
 Expected value to satisfy:
-  <green>[Function is2]</>
+  [Function is2]
 Received:
-  <red>3</>"
+  3"
 `;

--- a/src/matchers/toSatisfyAll/__snapshots__/index.test.js.snap
+++ b/src/matchers/toSatisfyAll/__snapshots__/index.test.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toSatisfyAll fails when all values satisfy predicate 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toSatisfyAll(</><green>expected</><dim>)</>
+"expect(received).not.toSatisfyAll(expected)
 
 Expected array to not satisfy predicate for all values:
-  <green>[Function isOdd]</>
+  [Function isOdd]
 Received:
-  <red>[1, 3, 5, 7]</>"
+  [1, 3, 5, 7]"
 `;
 
 exports[`.toSatisfyAll fails when any value does not satisfy the predicate 1`] = `
-"<dim>expect(</><red>received</><dim>).toSatisfyAll(</><green>expected</><dim>)</>
+"expect(received).toSatisfyAll(expected)
 
 Expected array to satisfy predicate for all values:
-  <green>[Function isOdd]</>
+  [Function isOdd]
 Received:
-  <red>[1, 3, 4, 5]</>"
+  [1, 3, 4, 5]"
 `;

--- a/src/matchers/toStartWith/__snapshots__/index.test.js.snap
+++ b/src/matchers/toStartWith/__snapshots__/index.test.js.snap
@@ -1,28 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toStartWith fails when string starts with given prefix 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toStartWith(</><green>expected</><dim>)</>
+"expect(received).not.toStartWith(expected)
 
 Expected string to not start with:
-  <green>\\"hello\\"</>
+  \\"hello\\"
 Received:
-  <red>\\"hello world\\"</>"
+  \\"hello world\\""
 `;
 
 exports[`.toStartWith fails when string does not start with the given prefix 1`] = `
-"<dim>expect(</><red>received</><dim>).toStartWith(</><green>expected</><dim>)</>
+"expect(received).toStartWith(expected)
 
 Expected string to start with:
-  <green>\\"world\\"</>
+  \\"world\\"
 Received:
-  <red>\\"hello world\\"</>"
+  \\"hello world\\""
 `;
 
 exports[`.toStartWith fails when the string is shorter than the given prefix 1`] = `
-"<dim>expect(</><red>received</><dim>).toStartWith(</><green>expected</><dim>)</>
+"expect(received).toStartWith(expected)
 
 Expected string to start with:
-  <green>\\"hello world\\"</>
+  \\"hello world\\"
 Received:
-  <red>\\"hello\\"</>"
+  \\"hello\\""
 `;

--- a/src/matchers/toThrowWithMessage/__snapshots__/index.test.js.snap
+++ b/src/matchers/toThrowWithMessage/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.toThrowWithMessage fails when a callback function is not a function 1`] = `
-"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+"expect(function).toThrowWithMessage(type, message)
 
 Received value must be a function but instead \\"2\\" was found"
 `;
@@ -12,29 +12,29 @@ But it didn't throw anything."
 `;
 
 exports[`.toThrowWithMessage fails when a wrong type of error is thrown 1`] = `
-"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+"expect(function).toThrowWithMessage(type, message)
 
 Expected to throw:
-  <green>[TypeError: Expected message]</>
+  [TypeError: Expected message]
 Thrown:
-  <red>[SyntaxError: Expected message]</>
+  [SyntaxError: Expected message]
 "
 `;
 
 exports[`.toThrowWithMessage fails when callback function is not provided 1`] = `
-"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+"expect(function).toThrowWithMessage(type, message)
 
 Received value must be a function but instead \\"undefined\\" was found"
 `;
 
 exports[`.toThrowWithMessage fails when error message is not provided 1`] = `
-"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+"expect(function).toThrowWithMessage(type, message)
 
  Message argument is required. "
 `;
 
 exports[`.toThrowWithMessage fails when error message provided is not a string or regex 1`] = `
-"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+"expect(function).toThrowWithMessage(type, message)
 
 Unexpected argument for message
 Expected: \\"string\\" or \\"regexp
@@ -42,27 +42,27 @@ Got: \\"2\\""
 `;
 
 exports[`.toThrowWithMessage fails when error type is not provided 1`] = `
-"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+"expect(function).toThrowWithMessage(type, message)
 
 Expected type to be a function but instead \\"undefined\\" was found"
 `;
 
 exports[`.toThrowWithMessage passes when given an Error with a regex error message 1`] = `
-"<dim>expect(</><red>function</><dim>).not.toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+"expect(function).not.toThrowWithMessage(type, message)
 
 Expected not to throw:
-  <green>[TypeError: /Expected message/]</>
+  [TypeError: /Expected message/]
 Thrown:
-  <red>[TypeError: Expected message]</>
+  [TypeError: Expected message]
 "
 `;
 
 exports[`.toThrowWithMessage passes when given an Error with a string error message 1`] = `
-"<dim>expect(</><red>function</><dim>).not.toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+"expect(function).not.toThrowWithMessage(type, message)
 
 Expected not to throw:
-  <green>[TypeError: Expected message]</>
+  [TypeError: Expected message]
 Thrown:
-  <red>[TypeError: Expected message]</>
+  [TypeError: Expected message]
 "
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,13 +9,163 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/code-frame@^7.0.0-beta.35":
-  version "7.0.0-beta.39"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.39.tgz#91c90bb65207fc5a55128cb54956ded39e850457"
+"@babel/code-frame@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
+  integrity sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==
   dependencies:
-    chalk "^2.0.0"
-    esutils "^2.0.2"
-    js-tokens "^3.0.0"
+    "@babel/highlight" "^7.14.5"
+
+"@babel/compat-data@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.5.tgz#8ef4c18e58e801c5c95d3c1c0f2874a2680fadea"
+  integrity sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w==
+
+"@babel/core@^7.1.0":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.5.tgz#d281f46a9905f07d1b3bf71ead54d9c7d89cb1e3"
+  integrity sha512-RN/AwP2DJmQTZSfiDaD+JQQ/J99KsIpOCfBE5pL+5jJSt7nI3nYGoAXZu+ffYSQ029NLs2DstZb+eR81uuARgg==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.14.5"
+    "@babel/helper-compilation-targets" "^7.14.5"
+    "@babel/helper-module-transforms" "^7.14.5"
+    "@babel/helpers" "^7.14.5"
+    "@babel/parser" "^7.14.5"
+    "@babel/template" "^7.14.5"
+    "@babel/traverse" "^7.14.5"
+    "@babel/types" "^7.14.5"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.14.5", "@babel/generator@^7.4.0":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.5.tgz#848d7b9f031caca9d0cd0af01b063f226f52d785"
+  integrity sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==
+  dependencies:
+    "@babel/types" "^7.14.5"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/helper-compilation-targets@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz#7a99c5d0967911e972fe2c3411f7d5b498498ecf"
+  integrity sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==
+  dependencies:
+    "@babel/compat-data" "^7.14.5"
+    "@babel/helper-validator-option" "^7.14.5"
+    browserslist "^4.16.6"
+    semver "^6.3.0"
+
+"@babel/helper-function-name@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz#89e2c474972f15d8e233b52ee8c480e2cfcd50c4"
+  integrity sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.14.5"
+    "@babel/template" "^7.14.5"
+    "@babel/types" "^7.14.5"
+
+"@babel/helper-get-function-arity@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz#25fbfa579b0937eee1f3b805ece4ce398c431815"
+  integrity sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==
+  dependencies:
+    "@babel/types" "^7.14.5"
+
+"@babel/helper-hoist-variables@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz#e0dd27c33a78e577d7c8884916a3e7ef1f7c7f8d"
+  integrity sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==
+  dependencies:
+    "@babel/types" "^7.14.5"
+
+"@babel/helper-member-expression-to-functions@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.5.tgz#d5c70e4ad13b402c95156c7a53568f504e2fb7b8"
+  integrity sha512-UxUeEYPrqH1Q/k0yRku1JE7dyfyehNwT6SVkMHvYvPDv4+uu627VXBckVj891BO8ruKBkiDoGnZf4qPDD8abDQ==
+  dependencies:
+    "@babel/types" "^7.14.5"
+
+"@babel/helper-module-imports@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz#6d1a44df6a38c957aa7c312da076429f11b422f3"
+  integrity sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==
+  dependencies:
+    "@babel/types" "^7.14.5"
+
+"@babel/helper-module-transforms@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz#7de42f10d789b423eb902ebd24031ca77cb1e10e"
+  integrity sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.14.5"
+    "@babel/helper-replace-supers" "^7.14.5"
+    "@babel/helper-simple-access" "^7.14.5"
+    "@babel/helper-split-export-declaration" "^7.14.5"
+    "@babel/helper-validator-identifier" "^7.14.5"
+    "@babel/template" "^7.14.5"
+    "@babel/traverse" "^7.14.5"
+    "@babel/types" "^7.14.5"
+
+"@babel/helper-optimise-call-expression@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz#f27395a8619e0665b3f0364cddb41c25d71b499c"
+  integrity sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==
+  dependencies:
+    "@babel/types" "^7.14.5"
+
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.8.0":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
+  integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
+
+"@babel/helper-replace-supers@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz#0ecc0b03c41cd567b4024ea016134c28414abb94"
+  integrity sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.14.5"
+    "@babel/helper-optimise-call-expression" "^7.14.5"
+    "@babel/traverse" "^7.14.5"
+    "@babel/types" "^7.14.5"
+
+"@babel/helper-simple-access@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz#66ea85cf53ba0b4e588ba77fc813f53abcaa41c4"
+  integrity sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==
+  dependencies:
+    "@babel/types" "^7.14.5"
+
+"@babel/helper-split-export-declaration@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz#22b23a54ef51c2b7605d851930c1976dd0bc693a"
+  integrity sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==
+  dependencies:
+    "@babel/types" "^7.14.5"
+
+"@babel/helper-validator-identifier@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
+  integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
+
+"@babel/helper-validator-option@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
+  integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
+
+"@babel/helpers@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.14.5.tgz#4870f8d9a6fdbbd65e5674a3558b4ff7fef0d9b2"
+  integrity sha512-xtcWOuN9VL6nApgVHtq3PPcQv5qFBJzoSZzJ/2c0QK/IP/gxVcoWSNQwFEGvmbQsuS9rhYqjILDGGXcTkA705Q==
+  dependencies:
+    "@babel/template" "^7.14.5"
+    "@babel/traverse" "^7.14.5"
+    "@babel/types" "^7.14.5"
 
 "@babel/highlight@^7.0.0":
   version "7.0.0"
@@ -26,9 +176,291 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@types/jest@^23.3.2":
-  version "23.3.2"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.2.tgz#07b90f6adf75d42c34230c026a2529e56c249dbb"
+"@babel/highlight@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
+  integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.5"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.5", "@babel/parser@^7.4.3":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.5.tgz#4cd2f346261061b2518873ffecdf1612cb032829"
+  integrity sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==
+
+"@babel/plugin-syntax-object-rest-spread@^7.0.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
+  integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/template@^7.14.5", "@babel/template@^7.4.0":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.14.5.tgz#a9bc9d8b33354ff6e55a9c60d1109200a68974f4"
+  integrity sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/parser" "^7.14.5"
+    "@babel/types" "^7.14.5"
+
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.14.5", "@babel/traverse@^7.4.3":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.5.tgz#c111b0f58afab4fea3d3385a406f692748c59870"
+  integrity sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.14.5"
+    "@babel/helper-function-name" "^7.14.5"
+    "@babel/helper-hoist-variables" "^7.14.5"
+    "@babel/helper-split-export-declaration" "^7.14.5"
+    "@babel/parser" "^7.14.5"
+    "@babel/types" "^7.14.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/types@^7.0.0", "@babel/types@^7.14.5", "@babel/types@^7.3.0", "@babel/types@^7.4.0":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.5.tgz#3bb997ba829a2104cedb20689c4a5b8121d383ff"
+  integrity sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.5"
+    to-fast-properties "^2.0.0"
+
+"@cnakazawa/watch@^1.0.3":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
+  integrity sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==
+  dependencies:
+    exec-sh "^0.3.2"
+    minimist "^1.2.0"
+
+"@jest/console@^24.7.1", "@jest/console@^24.9.0":
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
+  integrity sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==
+  dependencies:
+    "@jest/source-map" "^24.9.0"
+    chalk "^2.0.1"
+    slash "^2.0.0"
+
+"@jest/core@^24.9.0":
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-24.9.0.tgz#2ceccd0b93181f9c4850e74f2a9ad43d351369c4"
+  integrity sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==
+  dependencies:
+    "@jest/console" "^24.7.1"
+    "@jest/reporters" "^24.9.0"
+    "@jest/test-result" "^24.9.0"
+    "@jest/transform" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    exit "^0.1.2"
+    graceful-fs "^4.1.15"
+    jest-changed-files "^24.9.0"
+    jest-config "^24.9.0"
+    jest-haste-map "^24.9.0"
+    jest-message-util "^24.9.0"
+    jest-regex-util "^24.3.0"
+    jest-resolve "^24.9.0"
+    jest-resolve-dependencies "^24.9.0"
+    jest-runner "^24.9.0"
+    jest-runtime "^24.9.0"
+    jest-snapshot "^24.9.0"
+    jest-util "^24.9.0"
+    jest-validate "^24.9.0"
+    jest-watcher "^24.9.0"
+    micromatch "^3.1.10"
+    p-each-series "^1.0.0"
+    realpath-native "^1.1.0"
+    rimraf "^2.5.4"
+    slash "^2.0.0"
+    strip-ansi "^5.0.0"
+
+"@jest/environment@^24.9.0":
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-24.9.0.tgz#21e3afa2d65c0586cbd6cbefe208bafade44ab18"
+  integrity sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==
+  dependencies:
+    "@jest/fake-timers" "^24.9.0"
+    "@jest/transform" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    jest-mock "^24.9.0"
+
+"@jest/fake-timers@^24.9.0":
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-24.9.0.tgz#ba3e6bf0eecd09a636049896434d306636540c93"
+  integrity sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==
+  dependencies:
+    "@jest/types" "^24.9.0"
+    jest-message-util "^24.9.0"
+    jest-mock "^24.9.0"
+
+"@jest/reporters@^24.9.0":
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-24.9.0.tgz#86660eff8e2b9661d042a8e98a028b8d631a5b43"
+  integrity sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==
+  dependencies:
+    "@jest/environment" "^24.9.0"
+    "@jest/test-result" "^24.9.0"
+    "@jest/transform" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    chalk "^2.0.1"
+    exit "^0.1.2"
+    glob "^7.1.2"
+    istanbul-lib-coverage "^2.0.2"
+    istanbul-lib-instrument "^3.0.1"
+    istanbul-lib-report "^2.0.4"
+    istanbul-lib-source-maps "^3.0.1"
+    istanbul-reports "^2.2.6"
+    jest-haste-map "^24.9.0"
+    jest-resolve "^24.9.0"
+    jest-runtime "^24.9.0"
+    jest-util "^24.9.0"
+    jest-worker "^24.6.0"
+    node-notifier "^5.4.2"
+    slash "^2.0.0"
+    source-map "^0.6.0"
+    string-length "^2.0.0"
+
+"@jest/source-map@^24.3.0", "@jest/source-map@^24.9.0":
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-24.9.0.tgz#0e263a94430be4b41da683ccc1e6bffe2a191714"
+  integrity sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==
+  dependencies:
+    callsites "^3.0.0"
+    graceful-fs "^4.1.15"
+    source-map "^0.6.0"
+
+"@jest/test-result@^24.9.0":
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-24.9.0.tgz#11796e8aa9dbf88ea025757b3152595ad06ba0ca"
+  integrity sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==
+  dependencies:
+    "@jest/console" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+
+"@jest/test-sequencer@^24.9.0":
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz#f8f334f35b625a4f2f355f2fe7e6036dad2e6b31"
+  integrity sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==
+  dependencies:
+    "@jest/test-result" "^24.9.0"
+    jest-haste-map "^24.9.0"
+    jest-runner "^24.9.0"
+    jest-runtime "^24.9.0"
+
+"@jest/transform@^24.9.0":
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-24.9.0.tgz#4ae2768b296553fadab09e9ec119543c90b16c56"
+  integrity sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/types" "^24.9.0"
+    babel-plugin-istanbul "^5.1.0"
+    chalk "^2.0.1"
+    convert-source-map "^1.4.0"
+    fast-json-stable-stringify "^2.0.0"
+    graceful-fs "^4.1.15"
+    jest-haste-map "^24.9.0"
+    jest-regex-util "^24.9.0"
+    jest-util "^24.9.0"
+    micromatch "^3.1.10"
+    pirates "^4.0.1"
+    realpath-native "^1.1.0"
+    slash "^2.0.0"
+    source-map "^0.6.1"
+    write-file-atomic "2.4.1"
+
+"@jest/types@^24.9.0":
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
+  integrity sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^13.0.0"
+
+"@types/babel__core@^7.1.0":
+  version "7.1.14"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.14.tgz#faaeefc4185ec71c389f4501ee5ec84b170cc402"
+  integrity sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
+"@types/babel__generator@*":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.6.2.tgz#f3d71178e187858f7c45e30380f8f1b7415a12d8"
+  integrity sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@types/babel__template@*":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.4.0.tgz#0c888dd70b3ee9eebb6e4f200e809da0076262be"
+  integrity sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.11.1.tgz#654f6c4f67568e24c23b367e947098c6206fa639"
+  integrity sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==
+  dependencies:
+    "@babel/types" "^7.3.0"
+
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
+  integrity sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==
+
+"@types/istanbul-lib-report@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#c14c24f18ea8190c118ee7562b7ff99a36552686"
+  integrity sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+
+"@types/istanbul-reports@^1.1.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz#e875cc689e47bce549ec81f3df5e6f6f11cfaeb2"
+  integrity sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+    "@types/istanbul-lib-report" "*"
+
+"@types/jest@^24.0.0":
+  version "24.9.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.9.1.tgz#02baf9573c78f1b9974a5f36778b366aa77bd534"
+  integrity sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==
+  dependencies:
+    jest-diff "^24.3.0"
+
+"@types/stack-utils@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
+  integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/yargs-parser@*":
+  version "20.2.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.0.tgz#dd3e6699ba3237f0348cd085e4698780204842f9"
+  integrity sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==
+
+"@types/yargs@^13.0.0":
+  version "13.0.11"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.11.tgz#def2f0c93e4bdf2c61d7e34899b17e34be28d3b1"
+  integrity sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 abab@^1.0.4:
   version "1.0.4"
@@ -82,18 +514,6 @@ ajv@^5.1.0, ajv@^5.2.0, ajv@^5.2.3:
     json-schema-traverse "^0.3.0"
     json-stable-stringify "^1.0.1"
 
-align-text@^0.1.1, align-text@^0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
-  dependencies:
-    kind-of "^3.0.2"
-    longest "^1.0.1"
-    repeat-string "^1.5.2"
-
-amdefine@>=0.0.4:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
-
 ansi-escapes@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
@@ -114,6 +534,11 @@ ansi-regex@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
   integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
+
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -142,15 +567,17 @@ anymatch@^1.3.0:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
 
+anymatch@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
+  integrity sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==
+  dependencies:
+    micromatch "^3.1.4"
+    normalize-path "^2.1.1"
+
 app-root-path@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
-
-append-transform@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
-  dependencies:
-    default-require-extensions "^1.0.0"
 
 aproba@^1.0.3:
   version "1.2.0"
@@ -214,7 +641,7 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
 
-arrify@^1.0.0, arrify@^1.0.1:
+arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
@@ -245,16 +672,6 @@ async-each@^1.0.0:
 async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
-
-async@^1.4.0:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-
-async@^2.1.4:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
-  dependencies:
-    lodash "^4.14.0"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -313,7 +730,7 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.0.0, babel-core@^6.26.0:
+babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -346,7 +763,7 @@ babel-eslint@^8.0.1:
     babel-types "7.0.0-beta.0"
     babylon "7.0.0-beta.22"
 
-babel-generator@^6.18.0, babel-generator@^6.26.0:
+babel-generator@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.0.tgz#ac1ae20070b79f6e3ca1d3269613053774f20dc5"
   dependencies:
@@ -415,12 +832,18 @@ babel-jest-assertions@^0.1.0:
     babel-generator "^6.26.0"
     babel-types "^6.26.0"
 
-babel-jest@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.0.1.tgz#bbad3bf523fb202da05ed0a6540b48c84eed13a6"
+babel-jest@^24.0.0, babel-jest@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.9.0.tgz#3fc327cb8467b89d14d7bc70e315104a783ccd54"
+  integrity sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==
   dependencies:
-    babel-plugin-istanbul "^4.1.6"
-    babel-preset-jest "^23.0.1"
+    "@jest/transform" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    "@types/babel__core" "^7.1.0"
+    babel-plugin-istanbul "^5.1.0"
+    babel-preset-jest "^24.9.0"
+    chalk "^2.4.2"
+    slash "^2.0.0"
 
 babel-messages@7.0.0-beta.0:
   version "7.0.0-beta.0"
@@ -436,18 +859,22 @@ babel-plugin-gwt@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-gwt/-/babel-plugin-gwt-1.0.0.tgz#9570e513087d0f2f380f127e7a603a114c180df7"
 
-babel-plugin-istanbul@^4.1.6:
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
+babel-plugin-istanbul@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz#df4ade83d897a92df069c4d9a25cf2671293c854"
+  integrity sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==
   dependencies:
-    babel-plugin-syntax-object-rest-spread "^6.13.0"
-    find-up "^2.1.0"
-    istanbul-lib-instrument "^1.10.1"
-    test-exclude "^4.2.1"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    find-up "^3.0.0"
+    istanbul-lib-instrument "^3.3.0"
+    test-exclude "^5.2.3"
 
-babel-plugin-jest-hoist@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.0.1.tgz#eaa11c964563aea9c21becef2bdf7853f7f3c148"
+babel-plugin-jest-hoist@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz#4f837091eb407e01447c8843cbec546d0002d756"
+  integrity sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==
+  dependencies:
+    "@types/babel__traverse" "^7.0.6"
 
 babel-plugin-macros@^2.0.0:
   version "2.2.2"
@@ -459,7 +886,7 @@ babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
-babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
+babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
@@ -502,12 +929,13 @@ babel-polyfill@^6.26.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-preset-jest@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.0.1.tgz#631cc545c6cf021943013bcaf22f45d87fe62198"
+babel-preset-jest@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz#192b521e2217fb1d1f67cf73f70c336650ad3cdc"
+  integrity sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==
   dependencies:
-    babel-plugin-jest-hoist "^23.0.1"
-    babel-plugin-syntax-object-rest-spread "^6.13.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
+    babel-plugin-jest-hoist "^24.9.0"
 
 babel-register@^6.26.0:
   version "6.26.0"
@@ -537,7 +965,7 @@ babel-template@7.0.0-beta.0:
     babylon "7.0.0-beta.22"
     lodash "^4.2.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
+babel-template@^6.24.1, babel-template@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:
@@ -561,7 +989,7 @@ babel-traverse@7.0.0-beta.0:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
@@ -583,7 +1011,7 @@ babel-types@7.0.0-beta.0:
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-babel-types@^6.18.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -626,6 +1054,13 @@ bcrypt-pbkdf@^1.0.0:
 binary-extensions@^1.0.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"
+
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
 
 block-stream@*:
   version "0.0.9"
@@ -687,11 +1122,23 @@ browser-process-hrtime@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
 
-browser-resolve@^1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
+browser-resolve@^1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
+  integrity sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==
   dependencies:
     resolve "1.1.7"
+
+browserslist@^4.16.6:
+  version "4.16.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.6.tgz#d7901277a5a88e554ed305b183ec9b0c08f66fa2"
+  integrity sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==
+  dependencies:
+    caniuse-lite "^1.0.30001219"
+    colorette "^1.2.2"
+    electron-to-chromium "^1.3.723"
+    escalade "^3.1.1"
+    node-releases "^1.1.71"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -731,28 +1178,31 @@ callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
-callsites@^2.0.0:
+callsites@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
+camelcase@^5.0.0, camelcase@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+caniuse-lite@^1.0.30001219:
+  version "1.0.30001236"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001236.tgz#0a80de4cdf62e1770bb46a30d884fc8d633e3958"
+  integrity sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ==
+
+capture-exit@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
-
-camelcase@^1.0.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
-
-camelcase@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
+  integrity sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==
+  dependencies:
+    rsvp "^4.8.4"
 
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-
-center-align@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
-  dependencies:
-    align-text "^0.1.3"
-    lazy-cache "^1.0.3"
 
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
@@ -780,6 +1230,15 @@ chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chokidar@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -798,6 +1257,11 @@ chokidar@^1.6.1:
 ci-info@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.1.tgz#47b44df118c48d2597b56d342e7e25791060171a"
+
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
 circular-json@^0.3.1:
   version "0.3.3"
@@ -839,21 +1303,14 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
-cliui@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
+cliui@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
+  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
   dependencies:
-    center-align "^0.1.1"
-    right-align "^0.1.1"
-    wordwrap "0.0.2"
-
-cliui@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.0.0.tgz#743d4650e05f36d1ed2575b59638d87322bfbbcc"
-  dependencies:
-    string-width "^2.1.1"
-    strip-ansi "^4.0.0"
-    wrap-ansi "^2.0.0"
+    string-width "^3.1.0"
+    strip-ansi "^5.2.0"
+    wrap-ansi "^5.1.0"
 
 co@^4.6.0:
   version "4.6.0"
@@ -888,6 +1345,11 @@ color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
+colorette@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
+  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
+
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
@@ -897,10 +1359,6 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
 commander@^2.11.0, commander@^2.9.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
-
-compare-versions@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.2.1.tgz#a49eb7689d4caaf0b6db5220173fd279614000f7"
 
 component-emitter@^1.2.1:
   version "1.2.1"
@@ -939,6 +1397,13 @@ convert-source-map@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
+convert-source-map@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
+  integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
+  dependencies:
+    safe-buffer "~5.1.1"
+
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
@@ -974,6 +1439,17 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
     lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^6.0.0:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
@@ -1021,9 +1497,17 @@ debug@^3.0.1, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-decamelize@^1.0.0, decamelize@^1.1.1:
+debug@^4.1.0, debug@^4.1.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
+decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -1040,12 +1524,6 @@ deep-extend@~0.4.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
-
-default-require-extensions@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
-  dependencies:
-    strip-bom "^2.0.0"
 
 define-properties@^1.1.2:
   version "1.1.2"
@@ -1099,10 +1577,6 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-
 detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
@@ -1112,10 +1586,10 @@ diff-sequences@^24.0.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.0.0.tgz#cdf8e27ed20d8b8d3caccb4e0c0d8fe31a173013"
   integrity sha512-46OkIuVGBBnrC0soO/4LHu5LHGHx0uhP65OVz8XOrAJpqiCB2aVIuESvjI1F9oqebuvY8lekS1pt6TN7vt7qsw==
 
-diff@^3.2.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
-  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+diff-sequences@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
+  integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
 
 doctrine@1.5.0:
   version "1.5.0"
@@ -1143,9 +1617,26 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
+electron-to-chromium@^1.3.723:
+  version "1.3.752"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.752.tgz#0728587f1b9b970ec9ffad932496429aef750d09"
+  integrity sha512-2Tg+7jSl3oPxgsBsWKh5H83QazTkmWG/cnNwJplmyZc7KcN61+I10oUgaXSVk/NwfvN3BdkKDR4FYuRBQQ2v0A==
+
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+
+end-of-stream@^1.1.0:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
@@ -1170,6 +1661,11 @@ es-to-primitive@^1.1.1:
     is-callable "^1.1.1"
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
+
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -1305,15 +1801,14 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-exec-sh@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.1.tgz#163b98a6e89e6b65b47c2a28d215bc1f63989c38"
-  dependencies:
-    merge "^1.1.3"
+exec-sh@^0.3.2:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.6.tgz#ff264f9e325519a60cb5e273692943483cca63bc"
+  integrity sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w==
 
-execa@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+execa@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
@@ -1323,12 +1818,13 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
   dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
     is-stream "^1.1.0"
     npm-run-path "^2.0.0"
     p-finally "^1.0.0"
@@ -1367,17 +1863,6 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-expect@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-23.0.1.tgz#99131f2fd9115595f8cc3697401e7f0734d45fef"
-  dependencies:
-    ansi-styles "^3.2.0"
-    jest-diff "^23.0.1"
-    jest-get-type "^22.1.0"
-    jest-matcher-utils "^23.0.1"
-    jest-message-util "^23.0.0"
-    jest-regex-util "^23.0.0"
-
 expect@^24.1.0:
   version "24.1.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-24.1.0.tgz#88e73301c4c785cde5f16da130ab407bdaf8c0f2"
@@ -1388,6 +1873,18 @@ expect@^24.1.0:
     jest-matcher-utils "^24.0.0"
     jest-message-util "^24.0.0"
     jest-regex-util "^24.0.0"
+
+expect@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-24.9.0.tgz#b75165b4817074fa4a157794f46fe9f1ba15b6ca"
+  integrity sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==
+  dependencies:
+    "@jest/types" "^24.9.0"
+    ansi-styles "^3.2.0"
+    jest-get-type "^24.9.0"
+    jest-matcher-utils "^24.9.0"
+    jest-message-util "^24.9.0"
+    jest-regex-util "^24.9.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -1476,16 +1973,14 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
-
-fileset@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/fileset/-/fileset-2.0.3.tgz#8e7548a96d3cc2327ee5e674168723a333bba2a0"
-  dependencies:
-    glob "^7.0.3"
-    minimatch "^3.0.3"
 
 fill-range@^2.1.0:
   version "2.2.3"
@@ -1517,11 +2012,18 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
-find-up@^2.0.0, find-up@^2.1.0:
+find-up@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
 
 flat-cache@^1.2.1:
   version "1.3.0"
@@ -1589,12 +2091,13 @@ fsevents@^1.0.0:
     nan "^2.3.0"
     node-pre-gyp "^0.6.36"
 
-fsevents@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.3.tgz#11f82318f5fe7bb2cd22965a108e9306208216d8"
+fsevents@^1.2.7:
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.13.tgz#f325cb0455592428bcf11b383370ef70e3bfcc38"
+  integrity sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==
   dependencies:
-    nan "^2.3.0"
-    node-pre-gyp "^0.6.39"
+    bindings "^1.5.0"
+    nan "^2.12.1"
 
 fstream-ignore@^1.0.5:
   version "1.0.5"
@@ -1635,9 +2138,15 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-get-caller-file@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+gensync@^1.0.0-beta.2:
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
+  integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+get-caller-file@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-own-enumerable-property-symbols@^2.0.1:
   version "2.0.1"
@@ -1646,6 +2155,13 @@ get-own-enumerable-property-symbols@^2.0.1:
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
+get-stream@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -1697,6 +2213,11 @@ globals@^10.0.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-10.1.0.tgz#4425a1881be0d336b4a823a82a7be725d5dd987c"
 
+globals@^11.1.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
 globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -1717,19 +2238,14 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
+graceful-fs@^4.1.15:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
+  integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
-
-handlebars@^4.0.3:
-  version "4.0.11"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
-  dependencies:
-    async "^1.4.0"
-    optimist "^0.6.1"
-    source-map "^0.4.4"
-  optionalDependencies:
-    uglify-js "^2.6"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -1758,10 +2274,6 @@ has-ansi@^2.0.0:
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
-
-has-flag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
 has-flag@^2.0.0:
   version "2.0.0"
@@ -1851,6 +2363,11 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -1890,11 +2407,12 @@ import-all.macro@^2.0.3:
     babel-plugin-macros "^2.0.0"
     glob "^7.1.2"
 
-import-local@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
+import-local@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d"
+  integrity sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==
   dependencies:
-    pkg-dir "^2.0.0"
+    pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
 imurmurhash@^0.1.4:
@@ -1953,9 +2471,12 @@ invariant@^2.2.0, invariant@^2.2.2:
   dependencies:
     loose-envify "^1.0.0"
 
-invert-kv@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -1998,6 +2519,13 @@ is-ci@^1.0.10:
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
   dependencies:
     ci-info "^1.0.0"
+
+is-ci@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+  dependencies:
+    ci-info "^2.0.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -2080,9 +2608,10 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
-is-generator-fn@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-1.0.0.tgz#969d49e1bb3329f6bb7f09089be26578b2ddd46a"
+is-generator-fn@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
+  integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
@@ -2191,13 +2720,14 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
-is-utf8@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
-
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
+is-wsl@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
+  integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -2222,141 +2752,101 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-istanbul-api@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.3.1.tgz#4c3b05d18c0016d1022e079b98dc82c40f488954"
-  dependencies:
-    async "^2.1.4"
-    compare-versions "^3.1.0"
-    fileset "^2.0.2"
-    istanbul-lib-coverage "^1.2.0"
-    istanbul-lib-hook "^1.2.0"
-    istanbul-lib-instrument "^1.10.1"
-    istanbul-lib-report "^1.1.4"
-    istanbul-lib-source-maps "^1.2.4"
-    istanbul-reports "^1.3.0"
-    js-yaml "^3.7.0"
-    mkdirp "^0.5.1"
-    once "^1.4.0"
+istanbul-lib-coverage@^2.0.2, istanbul-lib-coverage@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz#675f0ab69503fad4b1d849f736baaca803344f49"
+  integrity sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==
 
-istanbul-lib-coverage@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
-
-istanbul-lib-hook@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.2.0.tgz#ae556fd5a41a6e8efa0b1002b1e416dfeaf9816c"
+istanbul-lib-instrument@^3.0.1, istanbul-lib-instrument@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz#a5f63d91f0bbc0c3e479ef4c5de027335ec6d630"
+  integrity sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==
   dependencies:
-    append-transform "^0.4.0"
+    "@babel/generator" "^7.4.0"
+    "@babel/parser" "^7.4.3"
+    "@babel/template" "^7.4.0"
+    "@babel/traverse" "^7.4.3"
+    "@babel/types" "^7.4.0"
+    istanbul-lib-coverage "^2.0.5"
+    semver "^6.0.0"
 
-istanbul-lib-instrument@^1.10.1:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
+istanbul-lib-report@^2.0.4:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz#5a8113cd746d43c4889eba36ab10e7d50c9b4f33"
+  integrity sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==
   dependencies:
-    babel-generator "^6.18.0"
-    babel-template "^6.16.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
-    babylon "^6.18.0"
-    istanbul-lib-coverage "^1.2.0"
-    semver "^5.3.0"
+    istanbul-lib-coverage "^2.0.5"
+    make-dir "^2.1.0"
+    supports-color "^6.1.0"
 
-istanbul-lib-report@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz#e886cdf505c4ebbd8e099e4396a90d0a28e2acb5"
+istanbul-lib-source-maps@^3.0.1:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz#284997c48211752ec486253da97e3879defba8c8"
+  integrity sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==
   dependencies:
-    istanbul-lib-coverage "^1.2.0"
-    mkdirp "^0.5.1"
-    path-parse "^1.0.5"
-    supports-color "^3.1.2"
+    debug "^4.1.1"
+    istanbul-lib-coverage "^2.0.5"
+    make-dir "^2.1.0"
+    rimraf "^2.6.3"
+    source-map "^0.6.1"
 
-istanbul-lib-source-maps@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz#cc7ccad61629f4efff8e2f78adb8c522c9976ec7"
+istanbul-reports@^2.2.6:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.2.7.tgz#5d939f6237d7b48393cc0959eab40cd4fd056931"
+  integrity sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==
   dependencies:
-    debug "^3.1.0"
-    istanbul-lib-coverage "^1.2.0"
-    mkdirp "^0.5.1"
-    rimraf "^2.6.1"
-    source-map "^0.5.3"
+    html-escaper "^2.0.0"
 
-istanbul-reports@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.3.0.tgz#2f322e81e1d9520767597dca3c20a0cce89a3554"
+jest-changed-files@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.9.0.tgz#08d8c15eb79a7fa3fc98269bc14b451ee82f8039"
+  integrity sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==
   dependencies:
-    handlebars "^4.0.3"
-
-jest-changed-files@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.0.1.tgz#f79572d0720844ea5df84c2a448e862c2254f60c"
-  dependencies:
+    "@jest/types" "^24.9.0"
+    execa "^1.0.0"
     throat "^4.0.0"
 
-jest-cli@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.0.1.tgz#351a5ba51cf28ecf20336d97a30b970d1f530a56"
+jest-cli@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-24.9.0.tgz#ad2de62d07472d419c6abc301fc432b98b10d2af"
+  integrity sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==
   dependencies:
-    ansi-escapes "^3.0.0"
+    "@jest/core" "^24.9.0"
+    "@jest/test-result" "^24.9.0"
+    "@jest/types" "^24.9.0"
     chalk "^2.0.1"
     exit "^0.1.2"
-    glob "^7.1.2"
-    graceful-fs "^4.1.11"
-    import-local "^1.0.0"
-    is-ci "^1.0.10"
-    istanbul-api "^1.3.1"
-    istanbul-lib-coverage "^1.2.0"
-    istanbul-lib-instrument "^1.10.1"
-    istanbul-lib-source-maps "^1.2.4"
-    jest-changed-files "^23.0.1"
-    jest-config "^23.0.1"
-    jest-environment-jsdom "^23.0.1"
-    jest-get-type "^22.1.0"
-    jest-haste-map "^23.0.1"
-    jest-message-util "^23.0.0"
-    jest-regex-util "^23.0.0"
-    jest-resolve-dependencies "^23.0.1"
-    jest-runner "^23.0.1"
-    jest-runtime "^23.0.1"
-    jest-snapshot "^23.0.1"
-    jest-util "^23.0.1"
-    jest-validate "^23.0.1"
-    jest-worker "^23.0.1"
-    micromatch "^2.3.11"
-    node-notifier "^5.2.1"
-    realpath-native "^1.0.0"
-    rimraf "^2.5.4"
-    slash "^1.0.0"
-    string-length "^2.0.0"
-    strip-ansi "^4.0.0"
-    which "^1.2.12"
-    yargs "^11.0.0"
+    import-local "^2.0.0"
+    is-ci "^2.0.0"
+    jest-config "^24.9.0"
+    jest-util "^24.9.0"
+    jest-validate "^24.9.0"
+    prompts "^2.0.1"
+    realpath-native "^1.1.0"
+    yargs "^13.3.0"
 
-jest-config@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.0.1.tgz#6798bff1247c7a390b1327193305001582fc58fa"
+jest-config@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-24.9.0.tgz#fb1bbc60c73a46af03590719efa4825e6e4dd1b5"
+  integrity sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==
   dependencies:
-    babel-core "^6.0.0"
-    babel-jest "^23.0.1"
+    "@babel/core" "^7.1.0"
+    "@jest/test-sequencer" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    babel-jest "^24.9.0"
     chalk "^2.0.1"
     glob "^7.1.1"
-    jest-environment-jsdom "^23.0.1"
-    jest-environment-node "^23.0.1"
-    jest-get-type "^22.1.0"
-    jest-jasmine2 "^23.0.1"
-    jest-regex-util "^23.0.0"
-    jest-resolve "^23.0.1"
-    jest-util "^23.0.1"
-    jest-validate "^23.0.1"
-    pretty-format "^23.0.1"
-
-jest-diff@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.0.1.tgz#3d49137cee12c320a4b4d2b4a6fa6e82d491a16a"
-  dependencies:
-    chalk "^2.0.1"
-    diff "^3.2.0"
-    jest-get-type "^22.1.0"
-    pretty-format "^23.0.1"
+    jest-environment-jsdom "^24.9.0"
+    jest-environment-node "^24.9.0"
+    jest-get-type "^24.9.0"
+    jest-jasmine2 "^24.9.0"
+    jest-regex-util "^24.3.0"
+    jest-resolve "^24.9.0"
+    jest-util "^24.9.0"
+    jest-validate "^24.9.0"
+    micromatch "^3.1.10"
+    pretty-format "^24.9.0"
+    realpath-native "^1.1.0"
 
 jest-diff@^24.0.0:
   version "24.0.0"
@@ -2368,9 +2858,20 @@ jest-diff@^24.0.0:
     jest-get-type "^24.0.0"
     pretty-format "^24.0.0"
 
-jest-docblock@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.0.1.tgz#deddd18333be5dc2415260a04ef3fce9276b5725"
+jest-diff@^24.3.0, jest-diff@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
+  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
+  dependencies:
+    chalk "^2.0.1"
+    diff-sequences "^24.9.0"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
+
+jest-docblock@^24.3.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-24.9.0.tgz#7970201802ba560e1c4092cc25cbedf5af5a8ce2"
+  integrity sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==
   dependencies:
     detect-newline "^2.1.0"
 
@@ -2380,27 +2881,39 @@ jest-each@^0.5.0:
   dependencies:
     sprintf-js "^1.0.3"
 
-jest-each@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-23.0.1.tgz#a6e5dbf530afc6bf9d74792dde69d8db70f84706"
+jest-each@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-24.9.0.tgz#eb2da602e2a610898dbc5f1f6df3ba86b55f8b05"
+  integrity sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==
   dependencies:
+    "@jest/types" "^24.9.0"
     chalk "^2.0.1"
-    pretty-format "^23.0.1"
+    jest-get-type "^24.9.0"
+    jest-util "^24.9.0"
+    pretty-format "^24.9.0"
 
-jest-environment-jsdom@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.0.1.tgz#da689eb9358dc16e5708abb208f4eb26a439575c"
+jest-environment-jsdom@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz#4b0806c7fc94f95edb369a69cc2778eec2b7375b"
+  integrity sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==
   dependencies:
-    jest-mock "^23.0.1"
-    jest-util "^23.0.1"
+    "@jest/environment" "^24.9.0"
+    "@jest/fake-timers" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    jest-mock "^24.9.0"
+    jest-util "^24.9.0"
     jsdom "^11.5.1"
 
-jest-environment-node@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.0.1.tgz#676b740e205f1f2be77241969e7812be824ee795"
+jest-environment-node@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-24.9.0.tgz#333d2d2796f9687f2aeebf0742b519f33c1cbfd3"
+  integrity sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==
   dependencies:
-    jest-mock "^23.0.1"
-    jest-util "^23.0.1"
+    "@jest/environment" "^24.9.0"
+    "@jest/fake-timers" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    jest-mock "^24.9.0"
+    jest-util "^24.9.0"
 
 jest-get-type@^21.2.0:
   version "21.2.0"
@@ -2409,10 +2922,6 @@ jest-get-type@^21.2.0:
 jest-get-type@^22.0.3:
   version "22.0.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.0.3.tgz#fa894b677c0fcd55eff3fd8ee28c7be942e32d36"
-
-jest-get-type@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.1.0.tgz#4e90af298ed6181edc85d2da500dbd2753e0d5a9"
 
 jest-get-type@^22.4.3:
   version "22.4.3"
@@ -2423,39 +2932,59 @@ jest-get-type@^24.0.0:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.0.0.tgz#36e72930b78e33da59a4f63d44d332188278940b"
   integrity sha512-z6/Eyf6s9ZDGz7eOvl+fzpuJmN9i0KyTt1no37/dHu8galssxz5ZEgnc1KaV8R31q1khxyhB4ui/X5ZjjPk77w==
 
-jest-haste-map@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.0.1.tgz#cd89052abfc8cba01f560bbec09d4f36aec25d4f"
-  dependencies:
-    fb-watchman "^2.0.0"
-    graceful-fs "^4.1.11"
-    jest-docblock "^23.0.1"
-    jest-serializer "^23.0.1"
-    jest-worker "^23.0.1"
-    micromatch "^2.3.11"
-    sane "^2.0.0"
+jest-get-type@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
+  integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
 
-jest-jasmine2@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.0.1.tgz#16d875356e6360872bba48426f7d31fdc1b0bcea"
+jest-haste-map@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-24.9.0.tgz#b38a5d64274934e21fa417ae9a9fbeb77ceaac7d"
+  integrity sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==
   dependencies:
+    "@jest/types" "^24.9.0"
+    anymatch "^2.0.0"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.15"
+    invariant "^2.2.4"
+    jest-serializer "^24.9.0"
+    jest-util "^24.9.0"
+    jest-worker "^24.9.0"
+    micromatch "^3.1.10"
+    sane "^4.0.3"
+    walker "^1.0.7"
+  optionalDependencies:
+    fsevents "^1.2.7"
+
+jest-jasmine2@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz#1f7b1bd3242c1774e62acabb3646d96afc3be6a0"
+  integrity sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@jest/environment" "^24.9.0"
+    "@jest/test-result" "^24.9.0"
+    "@jest/types" "^24.9.0"
     chalk "^2.0.1"
     co "^4.6.0"
-    expect "^23.0.1"
-    is-generator-fn "^1.0.0"
-    jest-diff "^23.0.1"
-    jest-each "^23.0.1"
-    jest-matcher-utils "^23.0.1"
-    jest-message-util "^23.0.0"
-    jest-snapshot "^23.0.1"
-    jest-util "^23.0.1"
-    pretty-format "^23.0.1"
+    expect "^24.9.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^24.9.0"
+    jest-matcher-utils "^24.9.0"
+    jest-message-util "^24.9.0"
+    jest-runtime "^24.9.0"
+    jest-snapshot "^24.9.0"
+    jest-util "^24.9.0"
+    pretty-format "^24.9.0"
+    throat "^4.0.0"
 
-jest-leak-detector@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.0.1.tgz#9dba07505ac3495c39d3ec09ac1e564599e861a0"
+jest-leak-detector@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz#b665dea7c77100c5c4f7dfcb153b65cf07dcf96a"
+  integrity sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==
   dependencies:
-    pretty-format "^23.0.1"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
 
 jest-matcher-utils@^22.0.0:
   version "22.0.3"
@@ -2464,14 +2993,6 @@ jest-matcher-utils@^22.0.0:
     chalk "^2.0.1"
     jest-get-type "^22.0.3"
     pretty-format "^22.0.3"
-
-jest-matcher-utils@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz#0c6c0daedf9833c2a7f36236069efecb4c3f6e5f"
-  dependencies:
-    chalk "^2.0.1"
-    jest-get-type "^22.1.0"
-    pretty-format "^23.0.1"
 
 jest-matcher-utils@^24.0.0:
   version "24.0.0"
@@ -2483,15 +3004,15 @@ jest-matcher-utils@^24.0.0:
     jest-get-type "^24.0.0"
     pretty-format "^24.0.0"
 
-jest-message-util@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-23.0.0.tgz#073f3d76c701f7c718a4b9af1eb7f138792c4796"
+jest-matcher-utils@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
+  integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
   dependencies:
-    "@babel/code-frame" "^7.0.0-beta.35"
     chalk "^2.0.1"
-    micromatch "^2.3.11"
-    slash "^1.0.0"
-    stack-utils "^1.0.1"
+    jest-diff "^24.9.0"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
 
 jest-message-util@^24.0.0:
   version "24.0.0"
@@ -2504,103 +3025,156 @@ jest-message-util@^24.0.0:
     slash "^2.0.0"
     stack-utils "^1.0.1"
 
-jest-mock@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.0.1.tgz#1569f477968c668fc728273a17c3767773b46357"
+jest-message-util@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.9.0.tgz#527f54a1e380f5e202a8d1149b0ec872f43119e3"
+  integrity sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@jest/test-result" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    "@types/stack-utils" "^1.0.1"
+    chalk "^2.0.1"
+    micromatch "^3.1.10"
+    slash "^2.0.0"
+    stack-utils "^1.0.1"
 
-jest-regex-util@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.0.0.tgz#dd5c1fde0c46f4371314cf10f7a751a23f4e8f76"
+jest-mock@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.9.0.tgz#c22835541ee379b908673ad51087a2185c13f1c6"
+  integrity sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==
+  dependencies:
+    "@jest/types" "^24.9.0"
+
+jest-pnp-resolver@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz#b704ac0ae028a89108a4d040b3f919dfddc8e33c"
+  integrity sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
 
 jest-regex-util@^24.0.0:
   version "24.0.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-24.0.0.tgz#4feee8ec4a358f5bee0a654e94eb26163cb9089a"
   integrity sha512-Jv/uOTCuC+PY7WpJl2mpoI+WbY2ut73qwwO9ByJJNwOCwr1qWhEW2Lyi2S9ZewUdJqeVpEBisdEVZSI+Zxo58Q==
 
-jest-resolve-dependencies@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.0.1.tgz#d01a10ddad9152c4cecdf5eac2b88571c4b6a64d"
-  dependencies:
-    jest-regex-util "^23.0.0"
-    jest-snapshot "^23.0.1"
+jest-regex-util@^24.3.0, jest-regex-util@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-24.9.0.tgz#c13fb3380bde22bf6575432c493ea8fe37965636"
+  integrity sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==
 
-jest-resolve@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.0.1.tgz#3f8403462b10a34c2df1d47aab5574c4935bcd24"
+jest-resolve-dependencies@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz#ad055198959c4cfba8a4f066c673a3f0786507ab"
+  integrity sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==
   dependencies:
-    browser-resolve "^1.11.2"
+    "@jest/types" "^24.9.0"
+    jest-regex-util "^24.3.0"
+    jest-snapshot "^24.9.0"
+
+jest-resolve@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-24.9.0.tgz#dff04c7687af34c4dd7e524892d9cf77e5d17321"
+  integrity sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==
+  dependencies:
+    "@jest/types" "^24.9.0"
+    browser-resolve "^1.11.3"
     chalk "^2.0.1"
-    realpath-native "^1.0.0"
+    jest-pnp-resolver "^1.2.1"
+    realpath-native "^1.1.0"
 
-jest-runner@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.0.1.tgz#b176ae3ecf9e194aa4b84a7fcf70d1b8db231aa7"
+jest-runner@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-24.9.0.tgz#574fafdbd54455c2b34b4bdf4365a23857fcdf42"
+  integrity sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==
   dependencies:
+    "@jest/console" "^24.7.1"
+    "@jest/environment" "^24.9.0"
+    "@jest/test-result" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    chalk "^2.4.2"
     exit "^0.1.2"
-    graceful-fs "^4.1.11"
-    jest-config "^23.0.1"
-    jest-docblock "^23.0.1"
-    jest-haste-map "^23.0.1"
-    jest-jasmine2 "^23.0.1"
-    jest-leak-detector "^23.0.1"
-    jest-message-util "^23.0.0"
-    jest-runtime "^23.0.1"
-    jest-util "^23.0.1"
-    jest-worker "^23.0.1"
+    graceful-fs "^4.1.15"
+    jest-config "^24.9.0"
+    jest-docblock "^24.3.0"
+    jest-haste-map "^24.9.0"
+    jest-jasmine2 "^24.9.0"
+    jest-leak-detector "^24.9.0"
+    jest-message-util "^24.9.0"
+    jest-resolve "^24.9.0"
+    jest-runtime "^24.9.0"
+    jest-util "^24.9.0"
+    jest-worker "^24.6.0"
     source-map-support "^0.5.6"
     throat "^4.0.0"
 
-jest-runtime@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.0.1.tgz#b1d765fb03fb6d4043805af270676a693f504d57"
+jest-runtime@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-24.9.0.tgz#9f14583af6a4f7314a6a9d9f0226e1a781c8e4ac"
+  integrity sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==
   dependencies:
-    babel-core "^6.0.0"
-    babel-plugin-istanbul "^4.1.6"
+    "@jest/console" "^24.7.1"
+    "@jest/environment" "^24.9.0"
+    "@jest/source-map" "^24.3.0"
+    "@jest/transform" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    "@types/yargs" "^13.0.0"
     chalk "^2.0.1"
-    convert-source-map "^1.4.0"
     exit "^0.1.2"
-    fast-json-stable-stringify "^2.0.0"
-    graceful-fs "^4.1.11"
-    jest-config "^23.0.1"
-    jest-haste-map "^23.0.1"
-    jest-message-util "^23.0.0"
-    jest-regex-util "^23.0.0"
-    jest-resolve "^23.0.1"
-    jest-snapshot "^23.0.1"
-    jest-util "^23.0.1"
-    jest-validate "^23.0.1"
-    micromatch "^2.3.11"
-    realpath-native "^1.0.0"
-    slash "^1.0.0"
-    strip-bom "3.0.0"
-    write-file-atomic "^2.1.0"
-    yargs "^11.0.0"
+    glob "^7.1.3"
+    graceful-fs "^4.1.15"
+    jest-config "^24.9.0"
+    jest-haste-map "^24.9.0"
+    jest-message-util "^24.9.0"
+    jest-mock "^24.9.0"
+    jest-regex-util "^24.3.0"
+    jest-resolve "^24.9.0"
+    jest-snapshot "^24.9.0"
+    jest-util "^24.9.0"
+    jest-validate "^24.9.0"
+    realpath-native "^1.1.0"
+    slash "^2.0.0"
+    strip-bom "^3.0.0"
+    yargs "^13.3.0"
 
-jest-serializer@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-23.0.1.tgz#a3776aeb311e90fe83fab9e533e85102bd164165"
+jest-serializer@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-24.9.0.tgz#e6d7d7ef96d31e8b9079a714754c5d5c58288e73"
+  integrity sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==
 
-jest-snapshot@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-23.0.1.tgz#6674fa19b9eb69a99cabecd415bddc42d6af3e7e"
+jest-snapshot@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-24.9.0.tgz#ec8e9ca4f2ec0c5c87ae8f925cf97497b0e951ba"
+  integrity sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==
   dependencies:
+    "@babel/types" "^7.0.0"
+    "@jest/types" "^24.9.0"
     chalk "^2.0.1"
-    jest-diff "^23.0.1"
-    jest-matcher-utils "^23.0.1"
+    expect "^24.9.0"
+    jest-diff "^24.9.0"
+    jest-get-type "^24.9.0"
+    jest-matcher-utils "^24.9.0"
+    jest-message-util "^24.9.0"
+    jest-resolve "^24.9.0"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    pretty-format "^23.0.1"
+    pretty-format "^24.9.0"
+    semver "^6.2.0"
 
-jest-util@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.0.1.tgz#68ea5bd7edb177d3059f9797259f8e0dacce2f99"
+jest-util@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-24.9.0.tgz#7396814e48536d2e85a37de3e4c431d7cb140162"
+  integrity sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==
   dependencies:
-    callsites "^2.0.0"
+    "@jest/console" "^24.9.0"
+    "@jest/fake-timers" "^24.9.0"
+    "@jest/source-map" "^24.9.0"
+    "@jest/test-result" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    callsites "^3.0.0"
     chalk "^2.0.1"
-    graceful-fs "^4.1.11"
-    is-ci "^1.0.10"
-    jest-message-util "^23.0.0"
+    graceful-fs "^4.1.15"
+    is-ci "^2.0.0"
     mkdirp "^0.5.1"
+    slash "^2.0.0"
     source-map "^0.6.0"
 
 jest-validate@^21.1.0:
@@ -2612,14 +3186,17 @@ jest-validate@^21.1.0:
     leven "^2.1.0"
     pretty-format "^21.2.1"
 
-jest-validate@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.0.1.tgz#cd9f01a89d26bb885f12a8667715e9c865a5754f"
+jest-validate@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-24.9.0.tgz#0775c55360d173cd854e40180756d4ff52def8ab"
+  integrity sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==
   dependencies:
+    "@jest/types" "^24.9.0"
+    camelcase "^5.3.1"
     chalk "^2.0.1"
-    jest-get-type "^22.1.0"
-    leven "^2.1.0"
-    pretty-format "^23.0.1"
+    jest-get-type "^24.9.0"
+    leven "^3.1.0"
+    pretty-format "^24.9.0"
 
 jest-watch-typeahead@^0.2.0:
   version "0.2.0"
@@ -2639,18 +3216,34 @@ jest-watcher@^23.1.0:
     chalk "^2.0.1"
     string-length "^2.0.0"
 
-jest-worker@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.0.1.tgz#9e649dd963ff4046026f91c4017f039a6aa4a7bc"
+jest-watcher@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-24.9.0.tgz#4b56e5d1ceff005f5b88e528dc9afc8dd4ed2b3b"
+  integrity sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==
   dependencies:
-    merge-stream "^1.0.1"
+    "@jest/test-result" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    "@types/yargs" "^13.0.0"
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    jest-util "^24.9.0"
+    string-length "^2.0.0"
 
-jest@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-23.0.1.tgz#0d083290ee4112cecfb780df6ff81332ed373201"
+jest-worker@^24.6.0, jest-worker@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.9.0.tgz#5dbfdb5b2d322e98567898238a9697bcce67b3e5"
+  integrity sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==
   dependencies:
-    import-local "^1.0.0"
-    jest-cli "^23.0.1"
+    merge-stream "^2.0.0"
+    supports-color "^6.1.0"
+
+jest@^24.0.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-24.9.0.tgz#987d290c05a08b52c56188c1002e368edb007171"
+  integrity sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==
+  dependencies:
+    import-local "^2.0.0"
+    jest-cli "^24.9.0"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -2661,7 +3254,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.7.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
+js-yaml@^3.9.0, js-yaml@^3.9.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -2712,6 +3305,11 @@ jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
 
+jsesc@^2.5.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
+  integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -2737,6 +3335,13 @@ json-stringify-safe@~5.0.1:
 json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+json5@^2.1.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+  dependencies:
+    minimist "^1.2.5"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -2771,15 +3376,10 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
-lazy-cache@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
-
-lcid@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
-  dependencies:
-    invert-kv "^1.0.0"
+kleur@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
+  integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
 left-pad@^1.2.0:
   version "1.2.0"
@@ -2788,6 +3388,11 @@ left-pad@^1.2.0:
 leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
+
+leven@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
+  integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
@@ -2869,16 +3474,6 @@ listr@^0.13.0:
     stream-to-observable "^0.2.0"
     strip-ansi "^3.0.1"
 
-load-json-file@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
-  dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^2.2.0"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-    strip-bom "^2.0.0"
-
 load-json-file@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
@@ -2888,11 +3483,29 @@ load-json-file@^2.0.0:
     pify "^2.0.0"
     strip-bom "^3.0.0"
 
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+    strip-bom "^3.0.0"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
   dependencies:
     p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
     path-exists "^3.0.0"
 
 lodash.cond@^4.3.0:
@@ -2903,7 +3516,7 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.13.1, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
@@ -2927,10 +3540,6 @@ log-update@^1.0.2:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
 
-longest@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
-
 loose-envify@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
@@ -2943,6 +3552,14 @@ lru-cache@^4.0.1:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+make-dir@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
+  dependencies:
+    pify "^4.0.1"
+    semver "^5.6.0"
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -2960,24 +3577,12 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mem@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
-  dependencies:
-    mimic-fn "^1.0.0"
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge-stream@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
-  dependencies:
-    readable-stream "^2.0.1"
-
-merge@^1.1.3:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
-  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
-
-micromatch@^2.1.5, micromatch@^2.3.11:
+micromatch@^2.1.5:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
   dependencies:
@@ -2995,7 +3600,7 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.1.10, micromatch@^3.1.8:
+micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -3044,9 +3649,10 @@ minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 mixin-deep@^1.2.0:
   version "1.3.2"
@@ -3066,9 +3672,19 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+nan@^2.12.1:
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
+  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
 nan@^2.3.0:
   version "2.7.0"
@@ -3095,16 +3711,28 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
-node-notifier@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.2.1.tgz#fa313dd08f5517db0e2502e5758d664ac69f9dea"
+node-modules-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
+  integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
+
+node-notifier@^5.4.2:
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.4.5.tgz#0cbc1a2b0f658493b4025775a13ad938e96091ef"
+  integrity sha512-tVbHs7DyTLtzOiN78izLA85zRqB9NvEXkAf014Vx3jtSvn/xBl6bR8ZYifj+dFcFrKI21huSQgJZ6ZtL3B4HfQ==
   dependencies:
     growly "^1.3.0"
-    semver "^5.4.1"
+    is-wsl "^1.1.0"
+    semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
 
@@ -3123,21 +3751,10 @@ node-pre-gyp@^0.6.36:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-node-pre-gyp@^0.6.39:
-  version "0.6.39"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
-  dependencies:
-    detect-libc "^1.0.2"
-    hawk "3.1.3"
-    mkdirp "^0.5.1"
-    nopt "^4.0.1"
-    npmlog "^4.0.2"
-    rc "^1.1.7"
-    request "2.81.0"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^2.2.1"
-    tar-pack "^3.4.0"
+node-releases@^1.1.71:
+  version "1.1.73"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
+  integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -3159,7 +3776,7 @@ normalize-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
-normalize-path@^2.0.0, normalize-path@^2.0.1:
+normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
@@ -3249,7 +3866,7 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-once@^1.3.0, once@^1.3.3, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -3265,13 +3882,6 @@ onetime@^2.0.0:
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
   dependencies:
     mimic-fn "^1.0.0"
-
-optimist@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
-  dependencies:
-    minimist "~0.0.1"
-    wordwrap "~0.0.2"
 
 optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
@@ -3297,14 +3907,6 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
-os-locale@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
-  dependencies:
-    execa "^0.7.0"
-    lcid "^1.0.0"
-    mem "^1.1.0"
-
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -3324,6 +3926,13 @@ output-file-sync@^1.1.2:
     mkdirp "^0.5.1"
     object-assign "^4.1.0"
 
+p-each-series@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-1.0.0.tgz#930f3d12dd1f50e7434457a22cd6f04ac6ad7f71"
+  integrity sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=
+  dependencies:
+    p-reduce "^1.0.0"
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
@@ -3332,15 +3941,39 @@ p-limit@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
 
+p-limit@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
+  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
 
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
+
 p-map@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+
+p-reduce@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
+  integrity sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -3396,7 +4029,7 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
@@ -3404,19 +4037,18 @@ path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
 
-path-type@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
-  dependencies:
-    graceful-fs "^4.1.2"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-
 path-type@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
   dependencies:
     pify "^2.0.0"
+
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
+  dependencies:
+    pify "^3.0.0"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -3434,6 +4066,11 @@ pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -3444,17 +4081,25 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pirates@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
+  integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
+  dependencies:
+    node-modules-regexp "^1.0.0"
+
 pkg-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
   dependencies:
     find-up "^1.0.0"
 
-pkg-dir@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
   dependencies:
-    find-up "^2.1.0"
+    find-up "^3.0.0"
 
 pluralize@^7.0.0:
   version "7.0.0"
@@ -3501,13 +4146,6 @@ pretty-format@^22.1.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-pretty-format@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.0.1.tgz#d61d065268e4c759083bccbca27a01ad7c7601f4"
-  dependencies:
-    ansi-regex "^3.0.0"
-    ansi-styles "^3.2.0"
-
 pretty-format@^24.0.0:
   version "24.0.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.0.0.tgz#cb6599fd73ac088e37ed682f61291e4678f48591"
@@ -3515,6 +4153,16 @@ pretty-format@^24.0.0:
   dependencies:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.0"
+
+pretty-format@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
+  integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
+  dependencies:
+    "@jest/types" "^24.9.0"
+    ansi-regex "^4.0.0"
+    ansi-styles "^3.2.0"
+    react-is "^16.8.4"
 
 private@^0.1.7:
   version "0.1.8"
@@ -3528,9 +4176,25 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
+prompts@^2.0.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.1.tgz#befd3b1195ba052f9fd2fde8a486c4e82ee77f61"
+  integrity sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==
+  dependencies:
+    kleur "^3.0.3"
+    sisteransi "^1.0.5"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -3564,12 +4228,10 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-read-pkg-up@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
-  dependencies:
-    find-up "^1.0.0"
-    read-pkg "^1.0.0"
+react-is@^16.8.4:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -3578,13 +4240,13 @@ read-pkg-up@^2.0.0:
     find-up "^2.0.0"
     read-pkg "^2.0.0"
 
-read-pkg@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
+read-pkg-up@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-4.0.0.tgz#1b221c6088ba7799601c808f91161c66e58f8978"
+  integrity sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==
   dependencies:
-    load-json-file "^1.0.0"
-    normalize-package-data "^2.3.2"
-    path-type "^1.0.0"
+    find-up "^3.0.0"
+    read-pkg "^3.0.0"
 
 read-pkg@^2.0.0:
   version "2.0.0"
@@ -3594,7 +4256,16 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
+
+readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -3615,9 +4286,10 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-realpath-native@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.0.tgz#7885721a83b43bd5327609f0ddecb2482305fdf0"
+realpath-native@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"
+  integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
 
@@ -3736,9 +4408,10 @@ require-from-string@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.1.tgz#c545233e9d7da6616e9d59adfb39fc9f588676ff"
 
-require-main-filename@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
 require-uncached@^1.0.3:
   version "1.0.3"
@@ -3793,18 +4466,17 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
-right-align@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
-  dependencies:
-    align-text "^0.1.1"
-
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   dependencies:
     glob "^7.1.3"
+
+rsvp@^4.8.4:
+  version "4.8.5"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
+  integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -3838,19 +4510,20 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-sane@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/sane/-/sane-2.3.0.tgz#3f3df584abf69e63d4bb74f0f8c42468e4d7d46b"
+sane@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/sane/-/sane-4.1.0.tgz#ed881fd922733a6c461bc189dc2b6c006f3ffded"
+  integrity sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==
   dependencies:
-    anymatch "^1.3.0"
-    exec-sh "^0.2.0"
+    "@cnakazawa/watch" "^1.0.3"
+    anymatch "^2.0.0"
+    capture-exit "^2.0.0"
+    exec-sh "^0.3.2"
+    execa "^1.0.0"
     fb-watchman "^2.0.0"
-    minimatch "^3.0.2"
+    micromatch "^3.1.4"
     minimist "^1.1.1"
     walker "~1.0.5"
-    watch "~0.18.0"
-  optionalDependencies:
-    fsevents "^1.1.1"
 
 sax@^1.2.4:
   version "1.2.4"
@@ -3860,9 +4533,15 @@ sax@^1.2.4:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
-semver@^5.4.1:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+semver@^5.5.0, semver@^5.6.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
+  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+
+semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -3907,6 +4586,11 @@ shellwords@^0.1.1:
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sisteransi@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
+  integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
 slash@^1.0.0:
   version "1.0.0"
@@ -3993,17 +4677,11 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
-source-map@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
-  dependencies:
-    amdefine ">=0.0.4"
-
-source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.6:
+source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.6.0:
+source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -4090,12 +4768,21 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
+string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string-width@^3.0.0, string-width@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
 
 string_decoder@~1.0.3:
   version "1.0.3"
@@ -4128,15 +4815,16 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-bom@3.0.0, strip-bom@^3.0.0:
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
+
+strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
-
-strip-bom@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
-  dependencies:
-    is-utf8 "^0.2.0"
 
 strip-eof@^1.0.0:
   version "1.0.0"
@@ -4154,12 +4842,6 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.2:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
-  dependencies:
-    has-flag "^1.0.0"
-
 supports-color@^4.0.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
@@ -4169,6 +4851,13 @@ supports-color@^4.0.0:
 supports-color@^5.3.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
+
+supports-color@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
+  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
 
@@ -4217,15 +4906,15 @@ tar@^2.2.1:
     fstream "^1.0.12"
     inherits "2"
 
-test-exclude@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
+test-exclude@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.2.3.tgz#c3d3e1e311eb7ee405e092dac10aefd09091eac0"
+  integrity sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==
   dependencies:
-    arrify "^1.0.1"
-    micromatch "^3.1.8"
-    object-assign "^4.1.0"
-    read-pkg-up "^1.0.1"
-    require-main-filename "^1.0.1"
+    glob "^7.1.3"
+    minimatch "^3.0.4"
+    read-pkg-up "^4.0.0"
+    require-main-filename "^2.0.0"
 
 text-table@~0.2.0:
   version "0.2.0"
@@ -4319,19 +5008,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-uglify-js@^2.6:
-  version "2.8.29"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
-  dependencies:
-    source-map "~0.5.1"
-    yargs "~3.10.0"
-  optionalDependencies:
-    uglify-to-browserify "~1.0.0"
-
-uglify-to-browserify@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
-
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
@@ -4416,18 +5092,12 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^0.1.2"
 
-walker@~1.0.5:
+walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
+  integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
-
-watch@~0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/watch/-/watch-0.18.0.tgz#28095476c6df7c90c963138990c0a5423eb4b986"
-  dependencies:
-    exec-sh "^0.2.0"
-    minimist "^1.2.0"
 
 webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
   version "4.0.2"
@@ -4451,7 +5121,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.2.10, which@^1.2.12, which@^1.2.9, which@^1.3.0:
+which@^1.2.10, which@^1.2.9, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
@@ -4463,37 +5133,28 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2"
 
-window-size@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
-
-wordwrap@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
-
-wordwrap@~0.0.2:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
-
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
-wrap-ansi@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
+wrap-ansi@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
   dependencies:
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
 
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
+write-file-atomic@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.1.tgz#d0b05463c188ae804396fd5ab2a370062af87529"
+  integrity sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==
   dependencies:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
@@ -4517,42 +5178,35 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
-y18n@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+y18n@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
+  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-yargs-parser@^9.0.2:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
   dependencies:
-    camelcase "^4.1.0"
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
 
-yargs@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
+yargs@^13.3.0:
+  version "13.3.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
+  integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
   dependencies:
-    cliui "^4.0.0"
-    decamelize "^1.1.1"
-    find-up "^2.1.0"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
     require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
+    require-main-filename "^2.0.0"
     set-blocking "^2.0.0"
-    string-width "^2.0.0"
+    string-width "^3.0.0"
     which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^9.0.2"
-
-yargs@~3.10.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
-  dependencies:
-    camelcase "^1.0.2"
-    cliui "^2.1.0"
-    decamelize "^1.0.0"
-    window-size "0.1.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.2"


### PR DESCRIPTION
We could use

```yaml
    env:
      FORCE_COLOR: 0
```

To disable color instead of updating Jest and using the commandline switch. However, there's no platform independent way (at least that I know of) to do this in package.json. `"test": "FORCE_COLOR=0 jest",` works with Bash, but not with Powershell, for example.