### PR TITLE
Fixes #228 - Add a '.toBeEmptyObject()' custom matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ If you've come here to help contribute - Thanks! Take a look at the [contributin
     - [.toBeWithin(start, end)](#tobewithinstart-end)
   - [Object](#object)
     - [.toBeObject()](#tobeobject)
+    - [.toBeEmptyObject()](#tobeemptyobject)
     - [.toContainKey(key)](#tocontainkeykey)
     - [.toContainKeys([keys])](#tocontainkeyskeys)
     - [.toContainAllKeys([keys])](#tocontainallkeyskeys)
@@ -600,6 +601,17 @@ test('passes when number is within given bounds', () => {
 ```
 
 ### Object
+
+#### .toBeEmptyObject()
+
+Use `.toBeEmptyObject` when checking if a value is an empty `Object`.
+
+```js
+test('passes when value is an empty object', () => {
+  expect({}).toBeEmptyObject();
+  expect({ a: 'hello' }).not.toBeEmptyObject();
+});
+```
 
 #### .toBeObject()
 

--- a/src/matchers/toBeEmptyObject/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeEmptyObject/__snapshots__/index.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toBeEmptyObject fails when given an empty object 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toBeEmptyObject(</><dim>)</>
+
+Expected value to not be an empty object, received:
+  <red>{}</>"
+`;
+
+exports[`.toBeEmptyObject fails when not given an empty object 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeEmptyObject(</><dim>)</>
+
+Expected value to be an empty object, received:
+  <red>{\\"property1\\": \\"something\\"}</>"
+`;

--- a/src/matchers/toBeEmptyObject/index.js
+++ b/src/matchers/toBeEmptyObject/index.js
@@ -1,0 +1,26 @@
+import { matcherHint, printReceived } from 'jest-matcher-utils';
+
+import predicate from './predicate';
+
+const passMessage = received => () =>
+  matcherHint('.not.toBeEmptyObject', 'received', '') +
+  '\n\n' +
+  'Expected value to not be an empty object, received:\n' +
+  `  ${printReceived(received)}`;
+
+const failMessage = received => () =>
+  matcherHint('.toBeEmptyObject', 'received', '') +
+  '\n\n' +
+  'Expected value to be an empty object, received:\n' +
+  `  ${printReceived(received)}`;
+
+export default {
+  toBeEmptyObject: expected => {
+    const pass = predicate(expected);
+    if (pass) {
+      return { pass: true, message: passMessage(expected) };
+    }
+
+    return { pass: false, message: failMessage(expected) };
+  }
+};

--- a/src/matchers/toBeEmptyObject/index.test.js
+++ b/src/matchers/toBeEmptyObject/index.test.js
@@ -1,0 +1,25 @@
+import each from 'jest-each';
+
+import matcher from './';
+
+expect.extend(matcher);
+
+describe('.toBeEmptyObject', () => {
+  test('passes when given an empty object', () => {
+    expect({}).toBeEmptyObject();
+  });
+
+  test('fails when not given an empty object', () => {
+    expect(() => expect({ property1: 'something' }).toBeEmptyObject()).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toBeEmptyObject', () => {
+  test('passes when not given an empty object', () => {
+    expect({ property1: 'something' }).not.toBeEmptyObject();
+  });
+
+  test('fails when given an empty object', () => {
+    expect(() => expect({}).not.toBeEmptyObject()).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/toBeEmptyObject/predicate.js
+++ b/src/matchers/toBeEmptyObject/predicate.js
@@ -1,0 +1,3 @@
+import getType from 'jest-get-type';
+
+export default expected => getType(expected) === 'object' && Object.keys(expected).length === 0;

--- a/src/matchers/toBeEmptyObject/predicate.test.js
+++ b/src/matchers/toBeEmptyObject/predicate.test.js
@@ -1,0 +1,11 @@
+import predicate from './predicate';
+
+describe('toBeEmptyObject Predicate', () => {
+  test('returns true when given an empty object', () => {
+    expect(predicate({})).toBe(true);
+  });
+
+  test('returns false when given a non-empty object', () => {
+    expect(predicate({ property1: 'something' })).toBe(false);
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -711,5 +711,10 @@ declare namespace jest {
      * @param {String | RegExp} message
      */
     toThrowWithMessage(type: Function, message: string | RegExp): any;
+
+    /**
+     * Use `.toBeEmptyObject` when checking if a value is an empty `Object`.
+     */
+    toBeEmptyObject(): R;
   }
 }


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/255.

> ### What changes are being made? (feature/bug)
> Adding 'toBeEmptyObject()' custom matcher.
> 
> ### Why are these changes necessary? Link any related issues
> Closes #228 by adding a new matcher.
> 
> ### Housekeeping
> * [x]  Unit tests
> * [x]  Documentation is up to date
> * [x]  No additional lint warnings
> * [x]  [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant