### PR TITLE
Fix determinePropertyMessage to return property if property is falsy

### DIFF
--- a/src/matchers/toBeArrayOfSize/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeArrayOfSize/__snapshots__/index.test.js.snap
@@ -7,7 +7,7 @@ Expected value to not be an array of size:
   <green>0</>
 Received:
   value: <red>[]</>
-  length: <red>\\"Not Accessible\\"</>"
+  length: <red>0</>"
 `;
 
 exports[`.toBeArrayOfSize fails when given neither a parameter nor an array 1`] = `
@@ -17,7 +17,7 @@ Expected value to be an array of size:
   <green>undefined</>
 Received:
   value: <red>[]</>
-  length: <red>\\"Not Accessible\\"</>"
+  length: <red>0</>"
 `;
 
 exports[`.toBeArrayOfSize fails when given type of [object Object] which is not an array 1`] = `
@@ -87,7 +87,7 @@ Expected value to be an array of size:
   <green>1</>
 Received:
   value: <red>[Function anonymous]</>
-  length: <red>\\"Not Accessible\\"</>"
+  length: <red>0</>"
 `;
 
 exports[`.toBeArrayOfSize fails when given type of undefined which is not an array 2`] = `

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,7 +5,7 @@ export const contains = (list, value) => {
 };
 
 export const determinePropertyMessage = (actual, property, message = 'Not Accessible') => {
-  return actual && actual[property] ? actual[property] : message;
+  return actual && actual.hasOwnProperty(property) ? actual[property] : message;
 };
 
 export { equals };

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -34,11 +34,19 @@ describe('Utils', () => {
     }
 
     {
-      const fn = () => {};
+      const arr = new Array();
+
+      test('returns property when it has a falsy one', () => {
+        expect(determinePropertyMessage(arr, 'length')).toBe(0);
+      });
+    }
+
+    {
+      const date = new Date();
       const errorMessage = 'bob';
 
       test('returns custom error message when it is passed one', () => {
-        expect(determinePropertyMessage(fn, 'length', errorMessage)).toBe(errorMessage);
+        expect(determinePropertyMessage(date, 'length', errorMessage)).toBe(errorMessage);
       });
     }
   });


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/257.

> ### What
> Fix `determinePropertyMessage()` to return property if property is falsy, instead of "Not Accessible".
> 
> ### Why
> When using `.toBeArrayOfSize()` on an empty array it fails saying the property length is "Not Accessible" when it should say it is not the right length.
> 
> What it does:
> 
> ```js
> expect([]).toBeArrayOfSize(1);
> 
> //    expect(received).toBeArrayOfSize(expected)
> //
> //    Expected value to be an array of size:
> //      1
> //    Received:
> //      value: []
> //      length: "Not Accessible"
> ```
> 
> What it should do:
> 
> ```js
> expect([]).toBeArrayOfSize(1);
> 
> //    expect(received).toBeArrayOfSize(expected)
> //
> //    Expected value to be an array of size:
> //      1
> //    Received:
> //      value: []
> //      length: 0
> ```
> 
> ### Notes
> Corrected the test about custom message since functions have a `length` property, and added a new test for the specific case mentioned.
> 
> ### Housekeeping
> * [x]  Unit tests
> * [x]  Documentation is up to date
> * [x]  No additional lint warnings
> * [x]  [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant