### PR TITLE
Add 'toBeBetween', 'toBeAfterOrEqualTo' and 'toBeBeforeOrEqualTo' matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ If you've come here to help contribute - Thanks! Take a look at the [contributin
     - [.toBeValidDate()](#tobevaliddate)
     - [.toBeAfter(date)](#tobeafterdate)
     - [.toBeBefore(date)](#tobebeforedate)
+    - [.toBeAfterOrEqualTo(date)](#tobeafterorequaltodate)
+    - [.toBeBeforeOrEqualTo(date)](#tobebeforeorequaltodate)
+    - [.toBeBetween(startDate, endDate)](#tobebetweenstartdate-enddate)
     - Further proposals in [#117](https://github.com/jest-community/jest-extended/issues/117) PRs welcome
   - [Function](#function)
     - [.toBeFunction()](#tobefunction)
@@ -411,6 +414,33 @@ test('passes when input is after date', () => {
 test('passes when input is before date', () => {
   expect(new Date('01/01/2018')).toBeBefore(new Date('01/01/2019'));
   expect('01/01/2019').not.toBeBefore(new Date('01/01/2018'));
+});
+```
+ ### .toBeAfterOrEqualTo(date)
+ Use `.toBeAfterOrEqualTo` when checking if a date equals to or occurs after `date`.
+ ```js
+test('passes when input is equal to or after date', () => {
+  expect(new Date('01/01/2019')).toBeAfterOrEqualTo(new Date('01/01/2018'));
+  expect(new Date('01/01/2019')).toBeAfterOrEqualTo(new Date('01/01/2019'));
+  expect('01/01/2018').not.toBeAfterOrEqualTo(new Date('01/01/2019'));
+});
+```
+ ### .toBeBeforeOrEqualTo(date)
+ Use `.toBeBeforeOrEqualTo` when checking if a date equals to or occurs before `date`.
+ ```js
+test('passes when input is equal to or before date', () => {
+  expect(new Date('01/01/2018')).toBeBeforeOrEqualTo(new Date('01/01/2019'));
+  expect(new Date('01/01/2018')).toBeBeforeOrEqualTo(new Date('01/01/2018'));
+  expect('01/01/2019').not.toBeBeforeOrEqualTo(new Date('01/01/2018'));
+});
+```
+ ### .toBeBetween(startDate, endDate)
+ Use `.toBeBetween` when checking if a date equals or occurs after `startDate` and equals or occurs before `endDate`.
+ ```js
+test('passes when input is in given date range', () => {
+  expect(new Date('05/01/2019')).toBeBetween(new Date('01/01/2019'), new Date('10/01/2019');
+  expect(new Date('05/01/2019')).toBeBetween(new Date('05/01/2019'), new Date('10/01/2019');
+  expect(new Date('01/01/2019')).not.toBeBetween(new Date('05/01/2019'), new Date('10/01/2019'));
 });
 ```
 

--- a/src/matchers/toBeAfterOrEqualTo/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeAfterOrEqualTo/__snapshots__/index.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toBeAfterOrEqualTo fails when given a later date 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toBeAfterOrEqualTo(</><dim>)</>
+
+Expected date to be after or equal to <red>2019-09-01T22:00:00.000Z</> but received:
+  <red>2019-09-10T22:00:00.000Z</>"
+`;
+
+exports[`.not.toBeAfterOrEqualTo fails when given an equal date 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toBeAfterOrEqualTo(</><dim>)</>
+
+Expected date to be after or equal to <red>2019-09-01T22:00:00.000Z</> but received:
+  <red>2019-09-01T22:00:00.000Z</>"
+`;
+
+exports[`.toBeAfterOrEqualTo fails when given an earlier date 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeAfterOrEqualTo(</><dim>)</>
+
+Expected date to be after or equal to <red>2019-09-10T22:00:00.000Z</> but received:
+  <red>2019-09-01T22:00:00.000Z</>"
+`;

--- a/src/matchers/toBeAfterOrEqualTo/index.js
+++ b/src/matchers/toBeAfterOrEqualTo/index.js
@@ -1,0 +1,26 @@
+import { matcherHint, printReceived } from 'jest-matcher-utils';
+
+import predicate from './predicate';
+
+const passMessage = (received, before) => () =>
+  matcherHint('.not.toBeAfterOrEqualTo', 'received', '') +
+  '\n\n' +
+  `Expected date to be after or equal to ${printReceived(before)} but received:\n` +
+  `  ${printReceived(received)}`;
+
+const failMessage = (received, before) => () =>
+  matcherHint('.toBeAfterOrEqualTo', 'received', '') +
+  '\n\n' +
+  `Expected date to be after or equal to ${printReceived(before)} but received:\n` +
+  `  ${printReceived(received)}`;
+
+export default {
+  toBeAfterOrEqualTo: (date, after) => {
+    const pass = predicate(date, after);
+    if (pass) {
+      return { pass: true, message: passMessage(date, after) };
+    }
+
+    return { pass: false, message: failMessage(date, after) };
+  }
+};

--- a/src/matchers/toBeAfterOrEqualTo/index.test.js
+++ b/src/matchers/toBeAfterOrEqualTo/index.test.js
@@ -1,0 +1,40 @@
+import matcher from './';
+
+expect.extend(matcher);
+
+const EARLIER = new Date('2019-09-01T22:00:00.000Z');
+const LATER = new Date('2019-09-10T22:00:00.000Z');
+
+describe('.toBeAfterOrEqualTo', () => {
+  test('passes when given a later date', () => {
+    expect(LATER).toBeAfterOrEqualTo(EARLIER);
+  });
+
+  test('passes when given an equal date', () => {
+    expect(EARLIER).toBeAfterOrEqualTo(EARLIER);
+  });
+
+  test('fails when given an earlier date', () => {
+    expect(() => {
+      expect(EARLIER).toBeAfterOrEqualTo(LATER);
+    }).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toBeAfterOrEqualTo', () => {
+  test('passes when given an earlier date', () => {
+    expect(EARLIER).not.toBeAfterOrEqualTo(LATER);
+  });
+
+  test('fails when given a later date', () => {
+    expect(() => {
+      expect(LATER).not.toBeAfterOrEqualTo(EARLIER);
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when given an equal date', () => {
+    expect(() => {
+      expect(EARLIER).not.toBeAfterOrEqualTo(EARLIER);
+    }).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/toBeAfterOrEqualTo/predicate.js
+++ b/src/matchers/toBeAfterOrEqualTo/predicate.js
@@ -1,0 +1,5 @@
+function toBeAfterOrEqualTo(date, after) {
+  return date >= after;
+}
+
+export default (date, after) => toBeAfterOrEqualTo(date, after);

--- a/src/matchers/toBeAfterOrEqualTo/predicate.test.js
+++ b/src/matchers/toBeAfterOrEqualTo/predicate.test.js
@@ -1,0 +1,18 @@
+import predicate from './predicate';
+
+const EARLIER = new Date('01/09/2019');
+const LATER = new Date('07/09/2019');
+
+describe('toBeAfterOrEqualTo Predicate', () => {
+  test('returns true when given an earlier date', () => {
+    expect(predicate(LATER, EARLIER)).toBe(true);
+  });
+
+  test('returns true when given an equal date', () => {
+    expect(predicate(EARLIER, EARLIER)).toBe(true);
+  });
+
+  test('returns false when given a later date', () => {
+    expect(predicate(EARLIER, LATER)).toBe(false);
+  });
+});

--- a/src/matchers/toBeBeforeOrEqualTo/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeBeforeOrEqualTo/__snapshots__/index.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toBeBeforeOrEqualTo fails when given an earlier date 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toBeBeforeOrEqualTo(</><dim>)</>
+
+Expected date to be before or equal to <red>2019-09-10T22:00:00.000Z</> but received:
+  <red>2019-09-01T22:00:00.000Z</>"
+`;
+
+exports[`.not.toBeBeforeOrEqualTo fails when given an equal date 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toBeBeforeOrEqualTo(</><dim>)</>
+
+Expected date to be before or equal to <red>2019-09-01T22:00:00.000Z</> but received:
+  <red>2019-09-01T22:00:00.000Z</>"
+`;
+
+exports[`.toBeBeforeOrEqualTo fails when given a later date 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeBeforeOrEqualTo(</><dim>)</>
+
+Expected date to be before or equal to <red>2019-09-01T22:00:00.000Z</> but received:
+  <red>2019-09-10T22:00:00.000Z</>"
+`;

--- a/src/matchers/toBeBeforeOrEqualTo/index.js
+++ b/src/matchers/toBeBeforeOrEqualTo/index.js
@@ -1,0 +1,26 @@
+import { matcherHint, printReceived } from 'jest-matcher-utils';
+
+import predicate from './predicate';
+
+const passMessage = (received, before) => () =>
+  matcherHint('.not.toBeBeforeOrEqualTo', 'received', '') +
+  '\n\n' +
+  `Expected date to be before or equal to ${printReceived(before)} but received:\n` +
+  `  ${printReceived(received)}`;
+
+const failMessage = (received, before) => () =>
+  matcherHint('.toBeBeforeOrEqualTo', 'received', '') +
+  '\n\n' +
+  `Expected date to be before or equal to ${printReceived(before)} but received:\n` +
+  `  ${printReceived(received)}`;
+
+export default {
+  toBeBeforeOrEqualTo: (date, before) => {
+    const pass = predicate(date, before);
+    if (pass) {
+      return { pass: true, message: passMessage(date, before) };
+    }
+
+    return { pass: false, message: failMessage(date, before) };
+  }
+};

--- a/src/matchers/toBeBeforeOrEqualTo/index.test.js
+++ b/src/matchers/toBeBeforeOrEqualTo/index.test.js
@@ -1,0 +1,40 @@
+import matcher from './';
+
+expect.extend(matcher);
+
+const EARLIER = new Date('2019-09-01T22:00:00.000Z');
+const LATER = new Date('2019-09-10T22:00:00.000Z');
+
+describe('.toBeBeforeOrEqualTo', () => {
+  test('passes when given an earlier date', () => {
+    expect(EARLIER).toBeBeforeOrEqualTo(LATER);
+  });
+
+  test('passes when given an equal date', () => {
+    expect(EARLIER).toBeBeforeOrEqualTo(EARLIER);
+  });
+
+  test('fails when given a later date', () => {
+    expect(() => {
+      expect(LATER).toBeBeforeOrEqualTo(EARLIER);
+    }).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toBeBeforeOrEqualTo', () => {
+  test('passes when given an earlier date', () => {
+    expect(LATER).not.toBeBeforeOrEqualTo(EARLIER);
+  });
+
+  test('fails when given an earlier date', () => {
+    expect(() => {
+      expect(EARLIER).not.toBeBeforeOrEqualTo(LATER);
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when given an equal date', () => {
+    expect(() => {
+      expect(EARLIER).not.toBeBeforeOrEqualTo(EARLIER);
+    }).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/toBeBeforeOrEqualTo/predicate.js
+++ b/src/matchers/toBeBeforeOrEqualTo/predicate.js
@@ -1,0 +1,5 @@
+function toBeBeforeOrEqualTo(date, before) {
+  return date <= before;
+}
+
+export default (date, before) => toBeBeforeOrEqualTo(date, before);

--- a/src/matchers/toBeBeforeOrEqualTo/predicate.test.js
+++ b/src/matchers/toBeBeforeOrEqualTo/predicate.test.js
@@ -1,0 +1,18 @@
+import predicate from './predicate';
+
+const EARLIER = new Date('01/09/2019');
+const LATER = new Date('07/09/2019');
+
+describe('toBeBeforeOrEqualTo Predicate', () => {
+  test('returns true when given a later date', () => {
+    expect(predicate(EARLIER, LATER)).toBe(true);
+  });
+
+  test('returns true when given an equal date', () => {
+    expect(predicate(EARLIER, EARLIER)).toBe(true);
+  });
+
+  test('returns false when given an earlier date', () => {
+    expect(predicate(LATER, EARLIER)).toBe(false);
+  });
+});

--- a/src/matchers/toBeBetween/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeBetween/__snapshots__/index.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toBeBefore fails when date is in given range 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toBeBetween(</><dim>)</>
+
+Expected date to be between <red>2019-09-01T22:00:00.000Z</> and <red>2019-09-10T22:00:00.000Z</> but received:
+  <red>2019-09-03T22:00:00.000Z</>"
+`;
+
+exports[`.toBeBetween fails when date is not in given range 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeBetween(</><dim>)</>
+
+Expected date to be between <red>2019-09-03T22:00:00.000Z</> and <red>2019-09-10T22:00:00.000Z</> but received:
+  <red>2019-09-01T22:00:00.000Z</>"
+`;

--- a/src/matchers/toBeBetween/index.js
+++ b/src/matchers/toBeBetween/index.js
@@ -1,0 +1,26 @@
+import { matcherHint, printReceived } from 'jest-matcher-utils';
+
+import predicate from './predicate';
+
+const passMessage = (received, startDate, endDate) => () =>
+  matcherHint('.not.toBeBetween', 'received', '') +
+  '\n\n' +
+  `Expected date to be between ${printReceived(startDate)} and ${printReceived(endDate)} but received:\n` +
+  `  ${printReceived(received)}`;
+
+const failMessage = (received, startDate, endDate) => () =>
+  matcherHint('.toBeBetween', 'received', '') +
+  '\n\n' +
+  `Expected date to be between ${printReceived(startDate)} and ${printReceived(endDate)} but received:\n` +
+  `  ${printReceived(received)}`;
+
+export default {
+  toBeBetween: (date, startDate, endDate) => {
+    const pass = predicate(date, startDate, endDate);
+    if (pass) {
+      return { pass: true, message: passMessage(date, startDate, endDate) };
+    }
+
+    return { pass: false, message: failMessage(date, startDate, endDate) };
+  }
+};

--- a/src/matchers/toBeBetween/index.test.js
+++ b/src/matchers/toBeBetween/index.test.js
@@ -1,0 +1,31 @@
+import matcher from './';
+
+expect.extend(matcher);
+
+const TESTDATE1 = new Date('2019-09-01T22:00:00.000Z');
+const TESTDATE2 = new Date('2019-09-10T22:00:00.000Z');
+const TESTDATE3 = new Date('2019-09-03T22:00:00.000Z');
+
+describe('.toBeBetween', () => {
+  test('passes when date is in given range', () => {
+    expect(TESTDATE3).toBeBetween(TESTDATE1, TESTDATE2);
+  });
+
+  test('fails when date is not in given range', () => {
+    expect(() => {
+      expect(TESTDATE1).toBeBetween(TESTDATE3, TESTDATE2);
+    }).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toBeBefore', () => {
+  test('passes when date is not in given range', () => {
+    expect(TESTDATE1).not.toBeBetween(TESTDATE3, TESTDATE2);
+  });
+
+  test('fails when date is in given range', () => {
+    expect(() => {
+      expect(TESTDATE3).not.toBeBetween(TESTDATE1, TESTDATE2);
+    }).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/toBeBetween/predicate.js
+++ b/src/matchers/toBeBetween/predicate.js
@@ -1,0 +1,5 @@
+function toBeBetween(date, startDate, endDate) {
+  return date >= startDate && date <= endDate;
+}
+
+export default (date, startDate, endDate) => toBeBetween(date, startDate, endDate);

--- a/src/matchers/toBeBetween/predicate.test.js
+++ b/src/matchers/toBeBetween/predicate.test.js
@@ -1,0 +1,15 @@
+import predicate from './predicate';
+
+const TESTDATE1 = new Date('01/09/2019');
+const TESTDATE2 = new Date('10/09/2019');
+const TESTDATE3 = new Date('03/09/2019');
+
+describe('toBeBetween Predicate', () => {
+  test('returns true when date is in given range', () => {
+    expect(predicate(TESTDATE3, TESTDATE1, TESTDATE2)).toBe(true);
+  });
+
+  test('returns false when date is not in given range', () => {
+    expect(predicate(TESTDATE1, TESTDATE3, TESTDATE2)).toBe(false);
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -711,5 +711,24 @@ declare namespace jest {
      * @param {String | RegExp} message
      */
     toThrowWithMessage(type: Function, message: string | RegExp): any;
+
+    /**
+     * Use `.toBeBetween` when checking if a date occurs between `startDate` and `endDate`.
+     * @param {Date} startDate
+     * @param {Date} endDate
+     */
+    toBeBetween(startDate: Date, endDate: Date): R;
+
+    /**
+     * Use `.toBeBeforeOrEqualTo` when checking if a date equals to or occurs before `date`.
+     * @param {Date} date
+     */
+    toBeBeforeOrEqualTo(date: Date): any;
+
+    /**
+     * Use `.toBeAfterOrEqualTo` when checking if a date equals to or occurs after `date`.
+     * @param {Date} date
+     */
+    toBeAfterOrEqualTo(date: Date): any;
   }
 }


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/229.

> ### What changes are being made? (feature/bug)
> Adding 'toBeBetween', 'toBeAfterOrEqualTo' and 'toBeBeforeOrEqualTo' date matchers.
> 
> ### Why are these changes necessary? Link any related issues
> New date matchers are being added as requested in issue #117
> 
> ### Housekeeping
> * [x]  Unit tests
> * [x]  Documentation is up to date
> * [x]  No additional lint warnings
> * [x]  [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant