### PR TITLE
Add toBeSymbol matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ If you've come here to help contribute - Thanks! Take a look at the [contributin
     - [.toInclude(substring)](#toincludesubstring)
     - [.toIncludeRepeated(substring, times)](#toincluderepeatedsubstring-times)
     - [.toIncludeMultiple([substring])](#toincludemultiplesubstring)
+  - [Symbol](#symbol)
+    - [.toBeSymbol()](#tobesymbol)
 - [LICENSE](#license)
 
 ## Installation
@@ -924,6 +926,19 @@ Use `.toIncludeMultiple` when checking if a `String` includes all of the given s
 test('passes when value includes all substrings', () => {
   expect('hello world').toIncludeMultiple(['world', 'hello']);
   expect('hello world').not.toIncludeMultiple(['world', 'hello', 'bob']);
+});
+```
+
+### Symbol
+
+#### .toBeSymbol()
+
+Use `.toBeSymbol` when checking if a value is a `Symbol`.
+
+```js
+test('passes when value is a symbol', () => {
+  expect(Symbol()).toBeSymbol();
+  expect(true).not.toBeSymbol();
 });
 ```
 

--- a/src/matchers/toBeSymbol/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeSymbol/__snapshots__/index.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toBeSymbol fails when given a symbol 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toBeSymbol(</><dim>)</>
+
+Expected value to not be a symbol, received:
+  <red>Symbol()</>"
+`;
+
+exports[`.toBeSymbol fails when not given a symbol 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeSymbol(</><dim>)</>
+
+Expected to receive a symbol, received:
+  <red>false</>"
+`;

--- a/src/matchers/toBeSymbol/index.js
+++ b/src/matchers/toBeSymbol/index.js
@@ -1,0 +1,26 @@
+import { matcherHint, printReceived } from 'jest-matcher-utils';
+
+import predicate from './predicate';
+
+const passMessage = received => () =>
+  matcherHint('.not.toBeSymbol', 'received', '') +
+  '\n\n' +
+  'Expected value to not be a symbol, received:\n' +
+  `  ${printReceived(received)}`;
+
+const failMessage = received => () =>
+  matcherHint('.toBeSymbol', 'received', '') +
+  '\n\n' +
+  'Expected to receive a symbol, received:\n' +
+  `  ${printReceived(received)}`;
+
+export default {
+  toBeSymbol: expected => {
+    const pass = predicate(expected);
+    if (pass) {
+      return { pass: true, message: passMessage(expected) };
+    }
+
+    return { pass: false, message: failMessage(expected) };
+  }
+};

--- a/src/matchers/toBeSymbol/index.test.js
+++ b/src/matchers/toBeSymbol/index.test.js
@@ -1,0 +1,35 @@
+import each from 'jest-each';
+
+import matcher from './';
+
+expect.extend(matcher);
+
+describe('.toBeSymbol', () => {
+  test('passes when given a symbol', () => {
+    expect(Symbol()).toBeSymbol();
+  });
+
+  test('fails when not given a symbol', () => {
+    expect(() => expect(false).toBeSymbol()).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toBeSymbol', () => {
+  each([
+    [false],
+    [''],
+    [0],
+    [{}],
+    [[]],
+    [undefined],
+    [null],
+    [NaN],
+    [() => {}]
+  ]).test('passes when not given a symbol: %s', given => {
+    expect(given).not.toBeSymbol();
+  });
+
+  test('fails when given a symbol', () => {
+    expect(() => expect(Symbol()).not.toBeSymbol()).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/toBeSymbol/predicate.js
+++ b/src/matchers/toBeSymbol/predicate.js
@@ -1,0 +1,1 @@
+export default expected => typeof expected === 'symbol';

--- a/src/matchers/toBeSymbol/predicate.test.js
+++ b/src/matchers/toBeSymbol/predicate.test.js
@@ -1,0 +1,15 @@
+import each from 'jest-each';
+import predicate from './predicate';
+
+describe('toBeSymbol Predicate', () => {
+  test('returns true when given a symbol', () => {
+    expect(predicate(Symbol())).toBe(true);
+  });
+
+  each([[false], [''], [0], [{}], [[]], [undefined], [null], [NaN], [() => {}]]).test(
+    'returns false when given: %s',
+    given => {
+      expect(predicate(given)).toBe(false);
+    }
+  );
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -355,6 +355,11 @@ declare namespace jest {
      * @param {String | RegExp} message
      */
     toThrowWithMessage(type: Function, message: string | RegExp): R;
+
+    /**
+     * Use `.toBeSymbol` when checking if a value is a `Symbol`.
+     */
+    toBeSymbol(): R;
   }
 
   // noinspection JSUnusedGlobalSymbols
@@ -711,5 +716,10 @@ declare namespace jest {
      * @param {String | RegExp} message
      */
     toThrowWithMessage(type: Function, message: string | RegExp): any;
+
+    /**
+     * Use `.toBeSymbol` when checking if a value is a `Symbol`.
+     */
+    toBeSymbol(): any;
   }
 }


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/217.

> ### What
> Added `.toBeSymbol` matcher.
> 
> ### Why
> Sometimes you want to test if something is a Symbol.
> 
> ### Notes
> Implementation copied from `.toBeFunction`.
> 
> I would usually open an issue before submitting a PR, but as this is pretty simple stuff, I've not bothered with an issue. If I've missed anything, please let me know and I'll amend this PR accordingly.
> 
> ### Housekeeping
> * [x]  Unit tests
> * [x]  Documentation is up to date
> * [x]  No additional lint warnings
> * [x]  [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant