### PR TITLE
✨ Implement toIncludeAllPartialMembers

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,9 @@ Use `.toIncludeAllPartialMembers` when checking if an `Array` contains all of th
 
 ```js
 test('passes when given array values match the partial members of the set', () => {
-  expect([{ foo: 'bar', baz: 'qux' }]).toIncludeAllMembers([{ foo: 'bar' }]);
+  expect([{ foo: 'bar', baz: 'qux' }]).toIncludeAllPartialMembers([
+    { foo: 'bar' },
+  ]);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If you've come here to help contribute - Thanks! Take a look at the [contributin
     - [.toBeArray()](#tobearray)
     - [.toBeArrayOfSize()](#tobearrayofsize)
     - [.toIncludeAllMembers([members])](#toincludeallmembersmembers)
+    - [.toIncludeAllPartialMembers([members])](#toincludeallpartialmembersmembers)
     - [.toIncludeAnyMembers([members])](#toincludeanymembersmembers)
     - [.toIncludeSameMembers([members])](#toincludesamemembersmembers)
     - [.toSatisfyAll(predicate)](#tosatisfyallpredicate)
@@ -290,6 +291,16 @@ Use `.toIncludeAllMembers` when checking if an `Array` contains all of the same 
 test('passes when given array values match the members of the set', () => {
   expect([1, 2, 3]).toIncludeAllMembers([2, 1, 3]);
   expect([1, 2, 2]).toIncludeAllMembers([2, 1]);
+});
+```
+
+#### .toIncludeAllPartialMembers([members])
+
+Use `.toIncludeAllPartialMembers` when checking if an `Array` contains all of the same partial members of a given set.
+
+```js
+test('passes when given array values match the partial members of the set', () => {
+  expect([{ foo: 'bar', baz: 'qux' }]).toIncludeAllMembers([{ foo: 'bar' }]);
 });
 ```
 

--- a/src/matchers/toIncludeAllPartialMembers/__snapshots__/index.test.js.snap
+++ b/src/matchers/toIncludeAllPartialMembers/__snapshots__/index.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toIncludeAllPartialMembers fails when array values matches the members of the set 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toIncludeAllPartialMembers(</><green>expected</><dim>)</>
+
+Expected list to not have all of the following partial members:
+  <green>[{\\"foo\\": \\"bar\\"}]</>
+Received:
+  <red>[{\\"hello\\": \\"world\\"}, {\\"baz\\": \\"qux\\", \\"foo\\": \\"bar\\"}]</>"
+`;
+
+exports[`.toIncludeAllPartialMembers fails when array values do not contain any of the members of the set 1`] = `
+"<dim>expect(</><red>received</><dim>).toIncludeAllPartialMembers(</><green>expected</><dim>)</>
+
+Expected list to have all of the following partial members:
+  <green>[{\\"foo\\": \\"qux\\"}]</>
+Received:
+  <red>[{\\"hello\\": \\"world\\"}, {\\"baz\\": \\"qux\\", \\"foo\\": \\"bar\\"}]</>"
+`;
+
+exports[`.toIncludeAllPartialMembers fails when expected object is not an array 1`] = `
+"<dim>expect(</><red>received</><dim>).toIncludeAllPartialMembers(</><green>expected</><dim>)</>
+
+Expected list to have all of the following partial members:
+  <green>1</>
+Received:
+  <red>[{\\"hello\\": \\"world\\"}, {\\"baz\\": \\"qux\\", \\"foo\\": \\"bar\\"}]</>"
+`;
+
+exports[`.toIncludeAllPartialMembers fails when given object is not an array 1`] = `
+"<dim>expect(</><red>received</><dim>).toIncludeAllPartialMembers(</><green>expected</><dim>)</>
+
+Expected list to have all of the following partial members:
+  <green>[{\\"foo\\": \\"bar\\"}]</>
+Received:
+  <red>1</>"
+`;

--- a/src/matchers/toIncludeAllPartialMembers/index.js
+++ b/src/matchers/toIncludeAllPartialMembers/index.js
@@ -1,0 +1,30 @@
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+
+import predicate from './predicate';
+
+const passMessage = (actual, expected) => () =>
+  matcherHint('.not.toIncludeAllPartialMembers') +
+  '\n\n' +
+  'Expected list to not have all of the following partial members:\n' +
+  `  ${printExpected(expected)}\n` +
+  'Received:\n' +
+  `  ${printReceived(actual)}`;
+
+const failMessage = (actual, expected) => () =>
+  matcherHint('.toIncludeAllPartialMembers') +
+  '\n\n' +
+  'Expected list to have all of the following partial members:\n' +
+  `  ${printExpected(expected)}\n` +
+  'Received:\n' +
+  `  ${printReceived(actual)}`;
+
+export default {
+  toIncludeAllPartialMembers: (actual, expected) => {
+    const pass = predicate(actual, expected);
+    if (pass) {
+      return { pass: true, message: passMessage(actual, expected) };
+    }
+
+    return { pass: false, message: failMessage(actual, expected) };
+  },
+};

--- a/src/matchers/toIncludeAllPartialMembers/index.test.js
+++ b/src/matchers/toIncludeAllPartialMembers/index.test.js
@@ -1,0 +1,41 @@
+import matcher from './';
+
+expect.extend(matcher);
+
+describe('.toIncludeAllPartialMembers', () => {
+  test('passes when array values matches the partial members of the set', () => {
+    expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).toIncludeAllPartialMembers([{ foo: 'bar' }]);
+  });
+
+  test('fails when array values do not contain any of the members of the set', () => {
+    expect(() =>
+      expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).toIncludeAllPartialMembers([{ foo: 'qux' }]),
+    ).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when given object is not an array', () => {
+    expect(() => expect(1).toIncludeAllPartialMembers([{ foo: 'bar' }])).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when expected object is not an array', () => {
+    expect(() =>
+      expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).toIncludeAllPartialMembers(1),
+    ).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toIncludeAllPartialMembers', () => {
+  test('passes when array values does not contain any members of the set', () => {
+    expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).not.toIncludeAllPartialMembers([{ foo: 'qux' }]);
+  });
+
+  test('passes when given object is not an array', () => {
+    expect(1).not.toIncludeAllPartialMembers([{ foo: 'bar' }]);
+  });
+
+  test('fails when array values matches the members of the set', () => {
+    expect(() =>
+      expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).not.toIncludeAllPartialMembers([{ foo: 'bar' }]),
+    ).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/toIncludeAllPartialMembers/predicate.js
+++ b/src/matchers/toIncludeAllPartialMembers/predicate.js
@@ -1,0 +1,6 @@
+import toContainAnyEntries from '../toContainAnyEntries/predicate';
+
+export default (array, set) =>
+  Array.isArray(array) &&
+  Array.isArray(set) &&
+  set.every(partial => array.some(value => toContainAnyEntries(value, Object.entries(partial))));

--- a/src/matchers/toIncludeAllPartialMembers/predicate.test.js
+++ b/src/matchers/toIncludeAllPartialMembers/predicate.test.js
@@ -1,0 +1,15 @@
+import predicate from './predicate';
+
+describe('toIncludeAllPartialMembers Predicate', () => {
+  describe('returns true', () => {
+    test('when Array contains all of the same nested partial members of given set', () => {
+      expect(predicate([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }], [{ foo: 'bar' }])).toBe(true);
+    });
+  });
+
+  describe('returns false', () => {
+    test('when Array contains does not contain all of the same nested partial members of given set', () => {
+      expect(predicate([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }], [{ foo: 'qux' }])).toBe(false);
+    });
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -71,6 +71,12 @@ declare namespace jest {
     toIncludeAllMembers(members: any[]): R;
 
     /**
+     * Use `.toIncludeAllPartialMembers` when checking if an `Array` contains all of the same partial members of a given set.
+     * @param {Array.<*>} members
+     */
+    toIncludeAllMembers(members: any[]): R;
+
+    /**
      * Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.
      * @param {Array.<*>} members
      */


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/210.

> ### What
> Implement `toIncludeAllPartialMembers` matcher.
> 
> ### Why
> Consider the following test:
> 
> ```js
> test('passes when given array values match the partial members of the set', () => {
>   expect([{ foo: 'bar', baz: 'qux' }]).toIncludeAllMembers([{ foo: 'bar' }]);
> });
> ```
> 
> I would like to assert that the provided array's objects partially contain all properties of the provided members. Currently, `toIncludeAllMembers` is the closest available matcher but it's too strict on matching the exact shape of each member.
> 
> What I need is the matcher to ignore additional properties and only partially match against the provided members.
> 
> ### Notes
> * As an alternative to a net new matcher, we could extend `toIncludeAllMembers` to accept an options object (e.g. `{ isPartial: true }`) that would configure the matcher to either partially or fully test for equality.
> * `toIncludeAnyPartialMembers` would be another potentially useful matcher, but I wanted to keep this PR small and focused.
> 
> ### Housekeeping
> * [x]  Unit tests
> * [x]  Documentation is up to date
> * [x]  No additional lint warnings
> * [x]  Add yourself to contributors list (`yarn contributor`)
> * [x]  [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant