### PR TITLE
Add toRejectWith

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -450,6 +450,17 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login":"EyalPerry",
+      "name": "Eyal Perry",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/9663481",
+      "profile": "https://stackoverflow.com/users/story/2223556",
+      "contributions": [
+        "code",
+        "doc",
+        "test"
+      ]
     }
   ],
   "repoType": "github"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ If you've come here to help contribute - Thanks! Take a look at the [contributin
   - [Promise](#promise)
     - [.toResolve()](#toresolve)
     - [.toReject()](#toreject)
+    - [.toRejectWith(error,comparer)](#torejectwitherror--comparer)
   - [String](#string)
     - [.toBeString()](#tobestring)
     - [.toBeHexadecimal(string)](#tobehexadecimal)
@@ -817,6 +818,27 @@ Use `.toReject` when checking if a promise is rejected.
 ```js
 test('passes when a promise rejects', async () => {
   await expect(Promise.reject()).toReject();
+});
+```
+
+#### .toRejectWith(error, predicate)
+
+Use `.toRejectWith` when checking if a promise is rejected with a specific error.
+
+```js
+test('passes when a promise rejects with a specific error', async () => {
+  const error = new Error('I am an error');
+  await expect(Promise.reject(error)).toRejectWith(error);
+});
+```
+
+Pass your own custom error comparer (Defaults to Object.is).
+
+```js
+test('passes when a promise rejects with a specific error', async () => {
+  const error = new Error('I am an error');
+  const comparer = (a,b) => a.message === b.message;
+  await expect(Promise.reject(error)).toRejectWith(new Error('I am an error'), comparer);
 });
 ```
 

--- a/src/matchers/toRejectWith/__snapshots__/index.test.js.snap
+++ b/src/matchers/toRejectWith/__snapshots__/index.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.toRejectWith fails when passed a promise which resolves 1`] = `
+"<dim>expect(</><red>received</><dim>).toRejectWith(</><dim>)</>
+
+Expected promise to reject with:
+  <green>[Error: expected error]</>
+However it resolved with:
+  <red>\\"resolved value\\"</>
+"
+`;
+
+exports[`.toRejectWith when passed a promise which rejects fails if error was not expected 1`] = `
+"<dim>expect(</><red>received</><dim>).toRejectWith(</><dim>)</>
+
+Expected promise to reject with:
+  <green>[Error: expected error]</>
+However it rejected with:
+  <red>[Error: unexpected error]</>
+"
+`;
+
+exports[`.toRejectWith when passed a promise which rejects fails if error was not expected according to custom comparer 1`] = `
+"<dim>expect(</><red>received</><dim>).toRejectWith(</><dim>)</>
+
+Expected promise to reject with:
+  <green>[Error: expected error]</>
+However it rejected with:
+  <red>[Error: expected error]</>
+"
+`;
+
+exports[`not.toRejectWith when passed a promise which rejects fails if error was expected 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toRejectWith(</><dim>)</>
+
+Expected promise not to reject with:
+  <red>[Error: expected error]</>
+But it did."
+`;
+
+exports[`not.toRejectWith when passed a promise which rejects fails if error was expected according to custom comparer 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toRejectWith(</><dim>)</>
+
+Expected promise not to reject with:
+  <red>[Error: expected error]</>
+But it did."
+`;

--- a/src/matchers/toRejectWith/__snapshots__/index.test.js.snap
+++ b/src/matchers/toRejectWith/__snapshots__/index.test.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`.toRejectWith fails when no expected error is specified 1`] = `
+"<dim>expect(</><red>received</><dim>).toRejectWith(</><dim>)</>
+
+Expected error not specified, however promise rejected with:
+  <red>[Error: expected error]</>
+"
+`;
+
 exports[`.toRejectWith fails when passed a promise which resolves 1`] = `
 "<dim>expect(</><red>received</><dim>).toRejectWith(</><dim>)</>
 

--- a/src/matchers/toRejectWith/index.js
+++ b/src/matchers/toRejectWith/index.js
@@ -23,6 +23,12 @@ const rejectedWithUnexpectedMessage = (error, caught) => () =>
   'However it rejected with:\n' +
   `  ${printReceived(caught)}\n`;
 
+const errorNotDefined = caught => () =>
+  matcherHint('.toRejectWith', 'received', '') +
+  '\n\n' +
+  'Expected error not specified, however promise rejected with:\n' +
+  `  ${printReceived(caught)}\n`;
+
 export default {
   toRejectWith: async (promise, error, comparer) => {
     try {
@@ -33,6 +39,14 @@ export default {
       };
     } catch (caught) {
       comparer = typeof comparer === 'function' ? comparer : Object.is;
+
+      if (typeof error === 'undefined') {
+        return {
+          pass: false,
+          message: errorNotDefined(caught)
+        };
+      }
+
       const pass = comparer(error, caught);
       const message = pass ? passMessage(error) : rejectedWithUnexpectedMessage(error, caught);
       return { pass, message };

--- a/src/matchers/toRejectWith/index.js
+++ b/src/matchers/toRejectWith/index.js
@@ -1,0 +1,41 @@
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+
+const passMessage = error => () =>
+  matcherHint('.not.toRejectWith', 'received', '') +
+  '\n\n' +
+  'Expected promise not to reject with:\n' +
+  `  ${printReceived(error)}\n` +
+  'But it did.';
+
+const resolvedMessage = (error, value) => () =>
+  matcherHint('.toRejectWith', 'received', '') +
+  '\n\n' +
+  'Expected promise to reject with:\n' +
+  `  ${printExpected(error)}\n` +
+  'However it resolved with:\n' +
+  `  ${printReceived(value)}\n`;
+
+const rejectedWithUnexpectedMessage = (error, caught) => () =>
+  matcherHint('.toRejectWith', 'received', '') +
+  '\n\n' +
+  'Expected promise to reject with:\n' +
+  `  ${printExpected(error)}\n` +
+  'However it rejected with:\n' +
+  `  ${printReceived(caught)}\n`;
+
+export default {
+  toRejectWith: async (promise, error, comparer) => {
+    try {
+      const value = await promise;
+      return {
+        pass: false,
+        message: resolvedMessage(error, value)
+      };
+    } catch (caught) {
+      comparer = typeof comparer === 'function' ? comparer : Object.is;
+      const pass = comparer(error, caught);
+      const message = pass ? passMessage(error) : rejectedWithUnexpectedMessage(error, caught);
+      return { pass, message };
+    }
+  }
+};

--- a/src/matchers/toRejectWith/index.js
+++ b/src/matchers/toRejectWith/index.js
@@ -23,7 +23,7 @@ const rejectedWithUnexpectedMessage = (error, caught) => () =>
   'However it rejected with:\n' +
   `  ${printReceived(caught)}\n`;
 
-const errorNotDefined = caught => () =>
+const errorNotDefinedMessage = caught => () =>
   matcherHint('.toRejectWith', 'received', '') +
   '\n\n' +
   'Expected error not specified, however promise rejected with:\n' +
@@ -43,7 +43,7 @@ export default {
       if (typeof error === 'undefined') {
         return {
           pass: false,
-          message: errorNotDefined(caught)
+          message: errorNotDefinedMessage(caught)
         };
       }
 

--- a/src/matchers/toRejectWith/index.test.js
+++ b/src/matchers/toRejectWith/index.test.js
@@ -8,6 +8,10 @@ const rejectsWithUnexpected = Promise.reject(new Error('unexpected error'));
 const resolvedPromise = Promise.resolve('resolved value');
 
 describe('.toRejectWith', () => {
+  it('fails when no expected error is specified', async () => {
+    await expect(expect(rejectsWithExpected).toRejectWith()).rejects.toThrowErrorMatchingSnapshot();
+  });
+
   it('fails when passed a promise which resolves', async () => {
     await expect(expect(resolvedPromise).toRejectWith(expectedError)).rejects.toThrowErrorMatchingSnapshot();
   });

--- a/src/matchers/toRejectWith/index.test.js
+++ b/src/matchers/toRejectWith/index.test.js
@@ -1,0 +1,64 @@
+import matcher from '.';
+
+expect.extend(matcher);
+
+const expectedError = new Error('expected error');
+const rejectsWithExpected = Promise.reject(expectedError);
+const rejectsWithUnexpected = Promise.reject(new Error('unexpected error'));
+const resolvedPromise = Promise.resolve('resolved value');
+
+describe('.toRejectWith', () => {
+  it('fails when passed a promise which resolves', async () => {
+    await expect(expect(resolvedPromise).toRejectWith(expectedError)).rejects.toThrowErrorMatchingSnapshot();
+  });
+
+  describe('when passed a promise which rejects', () => {
+    it('fails if error was not expected', async () => {
+      await expect(expect(rejectsWithUnexpected).toRejectWith(expectedError)).rejects.toThrowErrorMatchingSnapshot();
+    });
+
+    it('fails if error was not expected according to custom comparer', async () => {
+      const comparer = (error, caught) => false;
+      await expect(
+        expect(rejectsWithExpected).toRejectWith(expectedError, comparer)
+      ).rejects.toThrowErrorMatchingSnapshot();
+    });
+
+    it('passes if error was expected', () => {
+      expect(rejectsWithExpected).toRejectWith(expectedError);
+    });
+
+    it('passes if error was expected according to custom comparer', () => {
+      const comparer = (error, caught) => true;
+      expect(rejectsWithUnexpected).toRejectWith(expectedError, comparer);
+    });
+  });
+});
+
+describe('not.toRejectWith', () => {
+  it('passes when passed a promise which resolves', () => {
+    expect(resolvedPromise).not.toRejectWith(expectedError);
+  });
+
+  describe('when passed a promise which rejects', () => {
+    it('passes if error was not expected', () => {
+      expect(rejectsWithUnexpected).not.toRejectWith(expectedError);
+    });
+
+    it('passes if error was not expected according to custom comparer', () => {
+      const comparer = (error, caught) => false;
+      expect(rejectsWithExpected).not.toRejectWith(expectedError, comparer);
+    });
+
+    it('fails if error was expected', async () => {
+      await expect(expect(rejectsWithExpected).not.toRejectWith(expectedError)).rejects.toThrowErrorMatchingSnapshot();
+    });
+
+    it('fails if error was expected according to custom comparer', async () => {
+      const comparer = (error, caught) => true;
+      await expect(
+        expect(rejectsWithUnexpected).not.toRejectWith(expectedError, comparer)
+      ).rejects.toThrowErrorMatchingSnapshot();
+    });
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -665,6 +665,14 @@ declare namespace jest {
     toReject(): any;
 
     /**
+     * Use `.toRejectWith` when checking if a promise rejects with a specific error.
+     * 
+     * @param {any} error - error which the promise should reject with.
+     * @param {Function} comparer - compares between two errors. Defaults to Object.is
+     */
+    toRejectWith(error: any, comparer?: (a: any, b: any) => boolean): any;
+
+    /**
      * Use `.toBeString` when checking if a value is a `String`.
      */
     toBeString(): any;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -301,6 +301,14 @@ declare namespace jest {
     toReject(): R;
 
     /**
+     * Use `.toRejectWith` when checking if a promise rejects with a specific error.
+     * 
+     * @param {any} error - error which the promise should reject with.
+     * @param {Function} comparer - compares between two errors. Defaults to Object.is
+     */
+    toRejectWith(error: any, comparer?: (a: any, b: any) => boolean): R;
+
+    /**
      * Use `.toBeString` when checking if a value is a `String`.
      */
     toBeString(): R;


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/209.

> ### What
> Added the `toRejectWith` promise matcher.
> 
> ### Why
> Consider the below function:
> 
> ```js
>    const underTest = async (paramA, paramB) => {
>       const stepOne = await mockedDependency(paramA);
>       const stepTwo = await unmockedDependency(stepOne, paramB);
> 
>       if(someCondition(stepTwo)){
>            throw new Error('some invariant was not met');
>       }
> 
>       return { key: stepOne.someKey, value: stepTwo } 
>   };
> ```
> 
> #### Scenario
> I would like to ensure that the `underTest` function throws when `someCondition` is met.
> For this purpose, `jest-extended` introduces the `toReject` matcher, which introduces, IMHO- a testing anti pattern.
> 
> ```js
> await expect(underTest('a','b')).toReject();
> ```
> 
> #### Problem
> `toReject` will pass on any on the following conditions:
> 
> * due to test misconfiguration, `mockedDependency` returns undefined:
>   causing `unmockedDependency` to throw.
> * due to test misconfiguration, `mockedDependency` returns undefined:
>   `unmockedDependency` handles the undefined value properly, but computing the return value will throw when dereferencing `stepOne.someKey`.
> * the test is properly configured, but `unmockedDependency` has a bug which causes it to throw.
> 
> This, in turn- might cause an unwary developer to believe that all is well and that the invariants are correctly guarded- when this is not necessarily the case.
> 
> #### Solution
> The problem with `toReject` is that it does not make developers explicitly specify the expected cause for failure.
> 
> This PR introduces an alternative for `toReject` - `toRejectWith`:.
> 
> ```js
> const messageComparer = (a, b) => a.message === b.message;
> const expectedError = new Error('some invariant was not met');
> 
> await expect(underTest('a','b')).toRejecWith(expectedError, messageComparer);
> ```
> 
> #### Design Decisions
> * Uses `Object.is` under the hood when a comparer function is not specified because:
>   
>   * Anything in JS is throwable.
>   * Testing mocked functions which throw a dummy error is supported out of the box.
> * For more complex, user specific scenarios:
>   A comparer function can be passed as a second parameter.
> 
> ### Notes
> * I honestly believe `toReject` should be depracated due to the aforementioned reasons.
> * This matcher has no`predicate.js` module, since it enables passing in a custom 'error comparer' parameter which defaults to Object.is.
>   Hope this is acceptable, let me know if it isn't.
> * `yarn contributor` failed to work on my mac, so I added myself manually.
>   If this isn't ok, let me know how I can address this issue.
> * Pretty sure I am incorrectly handling the edge case when `.not` is used with this matcher and no error is specified.
>   Not sure regarding the correct way to address this.
>   Currently, there's no test for this.
>   I think it doesn't even make sense to use `.not` with this matcher.
>   Is there a way to prevent people from using it in that context?