### PR TITLE
Add toBeDateString matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ If you've come here to help contribute - Thanks! Take a look at the [contributin
   - [String](#string)
     - [.toBeString()](#tobestring)
     - [.toBeHexadecimal(string)](#tobehexadecimal)
+    - [.toBeDateString(string)](#tobedatestringstring)
     - [.toEqualCaseInsensitive(string)](#toequalcaseinsensitivestring)
     - [.toStartWith(prefix)](#tostartwithprefix)
     - [.toEndWith(suffix)](#toendwithsuffix)
@@ -855,6 +856,18 @@ test('passes when value is a valid hexadecimal', () => {
   expect('#FFF').toBeHexadecimal();
   expect('#000000').toBeHexadecimal();
   expect('#123ffg').not.toBeHexadecimal();
+});
+```
+
+#### .toBeDateString(string)
+
+Use `.toBeDateString` when checking if a value is a valid date string.
+
+```js
+test('passes when value is a valid toBeDateString', () => {
+  expect('2019-11-27T14:05:07.520Z').toBeDateString();
+  expect('11/12/21').toBeDateString();
+  expect('not a date').not.toBeDateString();
 });
 ```
 

--- a/src/matchers/toBeDateString/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeDateString/__snapshots__/index.test.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toBeDateString fails when given a date string 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeDateDateString(</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBeDateString(</><dim>)</>
 
 Expected value to not be a date string received:
   <red>\\"2018-01-01T13:00:00.000Z\\"</>"
 `;
 
 exports[`.toBeDateString fails when not given a date string 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeDateDateString(</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toBeDateString(</><dim>)</>
 
 Expected value to be a date string received:
   <red>\\"not a date\\"</>"

--- a/src/matchers/toBeDateString/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeDateString/__snapshots__/index.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toBeDateString fails when given a date string 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toBeDateDateString(</><dim>)</>
+
+Expected value to not be a date string received:
+  <red>\\"2018-01-01T13:00:00.000Z\\"</>"
+`;
+
+exports[`.toBeDateString fails when not given a date string 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeDateDateString(</><dim>)</>
+
+Expected value to be a date string received:
+  <red>\\"not a date\\"</>"
+`;

--- a/src/matchers/toBeDateString/index.js
+++ b/src/matchers/toBeDateString/index.js
@@ -3,13 +3,13 @@ import { matcherHint, printReceived } from 'jest-matcher-utils';
 import predicate from './predicate';
 
 const passMessage = received => () =>
-  matcherHint('.not.toBeDateDateString', 'received', '') +
+  matcherHint('.not.toBeDateString', 'received', '') +
   '\n\n' +
   'Expected value to not be a date string received:\n' +
   `  ${printReceived(received)}`;
 
 const failMessage = received => () =>
-  matcherHint('.toBeDateDateString', 'received', '') +
+  matcherHint('.toBeDateString', 'received', '') +
   '\n\n' +
   'Expected value to be a date string received:\n' +
   `  ${printReceived(received)}`;

--- a/src/matchers/toBeDateString/index.js
+++ b/src/matchers/toBeDateString/index.js
@@ -1,0 +1,26 @@
+import { matcherHint, printReceived } from 'jest-matcher-utils';
+
+import predicate from './predicate';
+
+const passMessage = received => () =>
+  matcherHint('.not.toBeDateDateString', 'received', '') +
+  '\n\n' +
+  'Expected value to not be a date string received:\n' +
+  `  ${printReceived(received)}`;
+
+const failMessage = received => () =>
+  matcherHint('.toBeDateDateString', 'received', '') +
+  '\n\n' +
+  'Expected value to be a date string received:\n' +
+  `  ${printReceived(received)}`;
+
+export default {
+  toBeDateString: expected => {
+    const pass = predicate(expected);
+    if (pass) {
+      return { pass: true, message: passMessage(expected) };
+    }
+
+    return { pass: false, message: failMessage(expected) };
+  }
+};

--- a/src/matchers/toBeDateString/index.test.js
+++ b/src/matchers/toBeDateString/index.test.js
@@ -1,0 +1,23 @@
+import matcher from './';
+
+expect.extend(matcher);
+
+describe('.toBeDateString', () => {
+  test('passes when given a date string', () => {
+    expect(new Date().toISOString()).toBeDateString();
+  });
+
+  test('fails when not given a date string', () => {
+    expect(() => expect('not a date').toBeDateString()).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toBeDateString', () => {
+  test('passes when not given a date string', () => {
+    expect('not a date').not.toBeDateString();
+  });
+
+  test('fails when given a date string', () => {
+    expect(() => expect('2018-01-01T13:00:00.000Z').not.toBeDateString()).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/toBeDateString/predicate.js
+++ b/src/matchers/toBeDateString/predicate.js
@@ -1,0 +1,3 @@
+const isDateString = value => !isNaN(Date.parse(value));
+
+export default isDateString;

--- a/src/matchers/toBeDateString/predicate.test.js
+++ b/src/matchers/toBeDateString/predicate.test.js
@@ -1,0 +1,11 @@
+import predicate from './predicate';
+
+describe('toBeDateString Predicate', () => {
+  test('returns true when given a date string', () => {
+    expect(predicate(new Date().toISOString())).toBe(true);
+  });
+
+  test('returns false when given a non date string', () => {
+    expect(predicate('not a date')).toBe(false);
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -119,6 +119,13 @@ declare namespace jest {
     toBeFunction(): R;
 
     /**
+    * Use `.toBeDateString` when checking if a value is a valid date string.
+    *
+    * @param {String} string
+    */
+    toBeDateString(string: string): R;
+
+    /**
      * Use `.toBeHexadecimal` when checking if a value is a valid HTML hex color.
      *
      * @param {String} string
@@ -473,6 +480,13 @@ declare namespace jest {
      * Use `.toBeFunction` when checking if a value is a `Function`.
      */
     toBeFunction(): any;
+
+    /**
+    * Use `.toBeDateString` when checking if a value is a valid date string.
+    *
+    * @param {String} string
+    */
+    toBeDateString(string: string): any;
 
     /**
      * Use `.toBeHexadecimal` when checking if a value is a valid HTML hex color.


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/252.

> Added a new matcher to check whether a string is in a date format.
> 
> A use-case example: when serializing a JS object with date values, those become strings, and when comparing against the returned json, it can be useful to use this matcher.
> 
> ### Housekeeping
> * [x]  Unit tests
> * [x]  Documentation is up to date
> * [x]  No additional lint warnings
> * [x]  [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant