### PR TITLE
Fix toHaveBeenCalledBefore/toHaveBeenCalledAfter type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -132,7 +132,7 @@ declare namespace jest {
      *
      * @param {Mock} mock
      */
-    toHaveBeenCalledBefore(mock: jest.Mock): R;
+    toHaveBeenCalledBefore(mock: jest.MockInstance<any, any>): R;
 
     /**
      * Use `.toHaveBeenCalledAfter` when checking if a `Mock` was called after another `Mock`.
@@ -141,7 +141,7 @@ declare namespace jest {
      *
      * @param {Mock} mock
      */
-    toHaveBeenCalledAfter(mock: jest.Mock): R;
+    toHaveBeenCalledAfter(mock: jest.MockInstance<any, any>): R;
 
     /**
      * Use `.toBeNumber` when checking if a value is a `Number`.
@@ -488,7 +488,7 @@ declare namespace jest {
      *
      * @param {Mock} mock
      */
-    toHaveBeenCalledBefore(mock: jest.Mock): any;
+    toHaveBeenCalledBefore(mock: jest.MockInstance<any, any>): any;
 
     /**
      * Use `.toHaveBeenCalledAfter` when checking if a `Mock` was called after another `Mock`.
@@ -497,7 +497,7 @@ declare namespace jest {
      *
      * @param {Mock} mock
      */
-    toHaveBeenCalledAfter(mock: jest.Mock): any;
+    toHaveBeenCalledAfter(mock: jest.MockInstance<any, any>): any;
 
     /**
      * Use `.toBeNumber` when checking if a value is a `Number`.


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/292.

> ### What
> I get a compiler error when passing a `jest.MockedFunction` type to `toHaveBeenCalledAfter()/toHaveBeenCalledBefore()`.
> 
> ### Why
> Code showing the issue.
> 
> ```ts
> import { func } from './some-func';
> import { SomeClass } from './some-class';
> 
> const mockFunc = func as jest.MockedFunction<typeof func>;
> const mockClass = SomeClass as jest.MockedClass<typeof SomeClass>;
> 
> jest.mock('./some-func');
> jest.mock('./some-class');
> 
> // all of the following statements generate a compiler error
> expect(jest.fn()).toHaveBeenCalledBefore(mockFunc);
> expect(jest.fn()).toHaveBeenCalledBefore(mockClass);
> expect(jest.fn()).toHaveBeenCalledAfter(mockFunc);
> expect(jest.fn()).toHaveBeenCalledAfter(mockClass);
> ```
> 
> I get this compiler error.
> 
> ```
>  Argument of type 'MockedFunction<() => void>' is not assignable to parameter of type 'Mock<any, any>'.
>   The types returned by 'mockClear().mockClear()' are incompatible between these types.
>     Type 'MockedFunction<() => void>' is not assignable to type 'Mock<any, any>'.
>       Type 'MockInstance<void, [()?]> & (() => void)' provides no match for the signature 'new (...args: any): any'.
> 
> 12. expect(jest.fn()).toHaveBeenCalledAfter(mockFunc);
> ```
> 
> Changing these to `jest.MockInstance` resolves the issue and should work for all use cases as both `jest.MockedFunction` and `jest.MockedClass` extend `jest.MockInstance`.
> 
> ### Notes
> ### Housekeeping
> * [x]  Unit tests
> * [x]  Documentation is up to date
> * [x]  No additional lint warnings
> * [x]  [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant