### PR TITLE
Handle `.not` cases in toThrowWithMessage

### DIFF
--- a/src/matchers/toThrowWithMessage/__snapshots__/index.test.js.snap
+++ b/src/matchers/toThrowWithMessage/__snapshots__/index.test.js.snap
@@ -1,53 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.toThrowWithMessage fails when a callback function is not a function 1`] = `
-"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
-
-Received value must be a function but instead \\"2\\" was found"
-`;
-
-exports[`.toThrowWithMessage fails when a callback provided doesnt throw an error 1`] = `
-"Expected the function to throw an error.
-But it didn't throw anything."
-`;
-
-exports[`.toThrowWithMessage fails when a wrong type of error is thrown 1`] = `
-"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
-
-Expected to throw:
-  <green>[TypeError: Expected message]</>
-Thrown:
-  <red>[SyntaxError: Expected message]</>
-"
-`;
-
-exports[`.toThrowWithMessage fails when callback function is not provided 1`] = `
-"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
-
-Received value must be a function but instead \\"undefined\\" was found"
-`;
-
-exports[`.toThrowWithMessage fails when error message is not provided 1`] = `
-"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
-
- Message argument is required. "
-`;
-
-exports[`.toThrowWithMessage fails when error message provided is not a string or regex 1`] = `
-"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
-
-Unexpected argument for message
-Expected: \\"string\\" or \\"regexp
-Got: \\"2\\""
-`;
-
-exports[`.toThrowWithMessage fails when error type is not provided 1`] = `
-"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
-
-Expected type to be a function but instead \\"undefined\\" was found"
-`;
-
-exports[`.toThrowWithMessage passes when given an Error with a regex error message 1`] = `
+exports[`.toThrowWithMessage fails when given an Error with a regex error message 1`] = `
 "<dim>expect(</><red>function</><dim>).not.toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
 
 Expected not to throw:
@@ -57,7 +10,7 @@ Thrown:
 "
 `;
 
-exports[`.toThrowWithMessage passes when given an Error with a string error message 1`] = `
+exports[`.toThrowWithMessage fails when given an Error with a string error message 1`] = `
 "<dim>expect(</><red>function</><dim>).not.toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
 
 Expected not to throw:
@@ -65,4 +18,98 @@ Expected not to throw:
 Thrown:
   <red>[TypeError: Expected message]</>
 "
+`;
+
+exports[`.toThrowWithMessage fails when given an message regex and test case fails 1`] = `
+"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+
+Expected to throw:
+  <green>[TypeError: /Expected message/]</>
+Thrown:
+  <red>[TypeError: Expected]</>
+"
+`;
+
+exports[`.toThrowWithMessage fails when given an message string and test case fails 1`] = `
+"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+
+Expected to throw:
+  <green>[TypeError: Expected message]</>
+Thrown:
+  <red>[TypeError: Expected]</>
+"
+`;
+
+exports[`.toThrowWithMessage validation fails when a message is not provided 1`] = `
+"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+
+ Message argument is required. "
+`;
+
+exports[`.toThrowWithMessage validation fails when a message is not provided 2`] = `
+"<dim>expect(</><red>function</><dim>).not.toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+
+ Message argument is required. "
+`;
+
+exports[`.toThrowWithMessage validation fails when a message is not string or regexp 1`] = `
+"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+
+Unexpected argument for message
+Expected: \\"string\\" or \\"regexp
+Got: \\"2\\""
+`;
+
+exports[`.toThrowWithMessage validation fails when a message is not string or regexp 2`] = `
+"<dim>expect(</><red>function</><dim>).not.toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+
+Unexpected argument for message
+Expected: \\"string\\" or \\"regexp
+Got: \\"2\\""
+`;
+
+exports[`.toThrowWithMessage validation fails when a type is not a function 1`] = `
+"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+
+Expected type to be a function but instead \\"undefined\\" was found"
+`;
+
+exports[`.toThrowWithMessage validation fails when a type is not a function 2`] = `
+"<dim>expect(</><red>function</><dim>).not.toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+
+Expected type to be a function but instead \\"undefined\\" was found"
+`;
+
+exports[`.toThrowWithMessage validation fails when callback function is not a function 1`] = `
+"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+
+Received value must be a function but instead \\"2\\" was found"
+`;
+
+exports[`.toThrowWithMessage validation fails when callback function is not a function 2`] = `
+"<dim>expect(</><red>function</><dim>).not.toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+
+Received value must be a function but instead \\"2\\" was found"
+`;
+
+exports[`.toThrowWithMessage validation fails when callback function is not provided 1`] = `
+"<dim>expect(</><red>function</><dim>).toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+
+Received value must be a function but instead \\"undefined\\" was found"
+`;
+
+exports[`.toThrowWithMessage validation fails when callback function is not provided 2`] = `
+"<dim>expect(</><red>function</><dim>).not.toThrowWithMessage(</><green>type</>, <green>message</><dim>)</>
+
+Received value must be a function but instead \\"undefined\\" was found"
+`;
+
+exports[`.toThrowWithMessage validation fails when error not thrown 1`] = `
+"Expected the function to throw an error.
+But it didn't throw anything."
+`;
+
+exports[`.toThrowWithMessage validation fails when error not thrown 2`] = `
+"Expected the function to throw an error.
+But it didn't throw anything."
 `;

--- a/src/matchers/toThrowWithMessage/index.js
+++ b/src/matchers/toThrowWithMessage/index.js
@@ -22,37 +22,34 @@ const failMessage = (received, expected) => () =>
   `  ${printReceived(received)}\n`;
 
 export default {
-  toThrowWithMessage: (callback, type, message) => {
+  toThrowWithMessage(callback, type, message) {
+    const hint = this.isNot ? negativeHint : positiveHint;
     if (!callback || typeof callback !== 'function') {
       return {
-        pass: false,
-        message: () => positiveHint + '\n\n' + `Received value must be a function but instead "${callback}" was found`
+        pass: this.isNot,
+        message: () => hint + '\n\n' + `Received value must be a function but instead "${callback}" was found`
       };
     }
 
     if (!type || typeof type !== 'function') {
       return {
-        pass: false,
-        message: () => positiveHint + '\n\n' + `Expected type to be a function but instead "${type}" was found`
+        pass: this.isNot,
+        message: () => hint + '\n\n' + `Expected type to be a function but instead "${type}" was found`
       };
     }
 
     if (!message) {
       return {
-        pass: false,
-        message: () => positiveHint + '\n\n' + ' Message argument is required. '
+        pass: this.isNot,
+        message: () => hint + '\n\n' + ' Message argument is required. '
       };
     }
 
     if (typeof message !== 'string' && !(message instanceof RegExp)) {
       return {
-        pass: false,
+        pass: this.isNot,
         message: () =>
-          positiveHint +
-          '\n\n' +
-          'Unexpected argument for message\n' +
-          'Expected: "string" or "regexp\n' +
-          `Got: "${message}"`
+          hint + '\n\n' + 'Unexpected argument for message\n' + 'Expected: "string" or "regexp\n' + `Got: "${message}"`
       };
     }
 
@@ -65,7 +62,7 @@ export default {
 
     if (!error) {
       return {
-        pass: false,
+        pass: this.isNot,
         message: () => 'Expected the function to throw an error.\n' + "But it didn't throw anything."
       };
     }

--- a/src/matchers/toThrowWithMessage/index.test.js
+++ b/src/matchers/toThrowWithMessage/index.test.js
@@ -1,85 +1,117 @@
 import matcher from './';
-const { toThrowWithMessage } = matcher;
 
 expect.extend(matcher);
 
 describe('.toThrowWithMessage', () => {
-  test('fails when callback function is not provided', () => {
-    const { pass, message } = toThrowWithMessage();
-    expect(pass).toBe(false);
-    expect(message()).toMatchSnapshot();
+  describe('validation', () => {
+    test('fails when callback function is not provided', () => {
+      expect(() => expect().toThrowWithMessage(TypeError, 'Expected message')).toThrowErrorMatchingSnapshot();
+
+      expect(() => expect().not.toThrowWithMessage(TypeError, 'Expected message')).toThrowErrorMatchingSnapshot();
+    });
+
+    test('fails when callback function is not a function', () => {
+      expect(() => expect(2).toThrowWithMessage(TypeError, 'Expected message')).toThrowErrorMatchingSnapshot();
+
+      expect(() => expect(2).not.toThrowWithMessage(TypeError, 'Expected message')).toThrowErrorMatchingSnapshot();
+    });
+
+    test('fails when error not thrown', () => {
+      expect(() => expect(() => {}).toThrowWithMessage(TypeError, 'Expected message')).toThrowErrorMatchingSnapshot();
+
+      expect(() =>
+        expect(() => {}).not.toThrowWithMessage(TypeError, 'Expected message')
+      ).toThrowErrorMatchingSnapshot();
+    });
+
+    test('fails when a type is not a function', () => {
+      expect(() =>
+        expect(() => {
+          throw new Error();
+        }).toThrowWithMessage()
+      ).toThrowErrorMatchingSnapshot();
+
+      expect(() =>
+        expect(() => {
+          throw new Error();
+        }).not.toThrowWithMessage()
+      ).toThrowErrorMatchingSnapshot();
+    });
+
+    test('fails when a message is not provided', () => {
+      expect(() =>
+        expect(() => {
+          throw new Error();
+        }).toThrowWithMessage(Error)
+      ).toThrowErrorMatchingSnapshot();
+
+      expect(() =>
+        expect(() => {
+          throw new Error();
+        }).not.toThrowWithMessage(Error)
+      ).toThrowErrorMatchingSnapshot();
+    });
+
+    test('fails when a message is not string or regexp', () => {
+      expect(() =>
+        expect(() => {
+          throw new Error();
+        }).toThrowWithMessage(Error, 2)
+      ).toThrowErrorMatchingSnapshot();
+
+      expect(() =>
+        expect(() => {
+          throw new Error();
+        }).not.toThrowWithMessage(Error, 2)
+      ).toThrowErrorMatchingSnapshot();
+    });
   });
 
-  test('fails when a callback function is not a function', () => {
-    const { pass, message } = toThrowWithMessage(2);
-    expect(pass).toBe(false);
-    expect(message()).toMatchSnapshot();
+  test('passes when given an message string and test case passes', () => {
+    expect(() =>
+      expect(() => {
+        throw TypeError('Expected message');
+      }).toThrowWithMessage(TypeError, 'Expected message')
+    ).not.toThrowError();
   });
 
-  test('fails when error message is not provided', () => {
-    const callback = () => {};
-    const { pass, message } = toThrowWithMessage(callback, Error);
-    expect(pass).toBe(false);
-    expect(message()).toMatchSnapshot();
+  test('passes when given a message regex and test case passes', () => {
+    expect(() =>
+      expect(() => {
+        throw TypeError('Expected message');
+      }).toThrowWithMessage(TypeError, /Expected message/)
+    ).not.toThrowError();
   });
 
-  test('fails when error type is not provided', () => {
-    const callback = () => {};
-    const { pass, message } = toThrowWithMessage(callback);
-    expect(pass).toBe(false);
-    expect(message()).toMatchSnapshot();
+  test('fails when given an message string and test case fails', () => {
+    expect(() =>
+      expect(() => {
+        throw TypeError('Expected');
+      }).toThrowWithMessage(TypeError, 'Expected message')
+    ).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when error message provided is not a string or regex', () => {
-    const callback = () => {};
-    const { pass, message } = toThrowWithMessage(callback, Error, 2);
-    expect(pass).toBe(false);
-    expect(message()).toMatchSnapshot();
+  test('fails when given an message regex and test case fails', () => {
+    expect(() =>
+      expect(() => {
+        throw TypeError('Expected');
+      }).toThrowWithMessage(TypeError, /Expected message/)
+    ).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when a callback provided doesnt throw an error', () => {
-    const callback = () => {};
-    const { pass, message } = toThrowWithMessage(callback, Error, 'error');
-    expect(pass).toBe(false);
-    expect(message()).toMatchSnapshot();
+  test('fails when given an Error with a string error message', () => {
+    expect(() =>
+      expect(() => {
+        throw TypeError('Expected message');
+      }).not.toThrowWithMessage(TypeError, 'Expected message')
+    ).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when a wrong type of error is thrown', () => {
-    const callback = () => {
-      throw SyntaxError('Expected message');
-    };
-    const { pass, message } = toThrowWithMessage(callback, TypeError, 'Expected message');
-    expect(pass).toBe(false);
-    expect(message()).toMatchSnapshot();
-  });
-
-  test('passes when given an Error with a string error message', () => {
-    const callback = () => {
-      throw TypeError('Expected message');
-    };
-    const { pass, message } = toThrowWithMessage(callback, TypeError, 'Expected message');
-    expect(pass).toBe(true);
-    expect(message()).toMatchSnapshot();
-  });
-
-  test('passes when given an Error with a regex error message', () => {
-    const callback = () => {
-      throw TypeError('Expected message');
-    };
-    const { pass, message } = toThrowWithMessage(callback, TypeError, /Expected message/);
-    expect(pass).toBe(true);
-    expect(message()).toMatchSnapshot();
-  });
-
-  test('passes when given an Error with a string error message: end to end', () => {
-    expect(() => {
-      throw new TypeError('Expected message');
-    }).toThrowWithMessage(TypeError, 'Expected message');
-  });
-
-  test('passes when given an Error with a regex error message: end to end', () => {
-    expect(() => {
-      throw new SyntaxError('Expected message');
-    }).toThrowWithMessage(SyntaxError, /Expected message/);
+  test('fails when given an Error with a regex error message', () => {
+    expect(() =>
+      expect(() => {
+        throw TypeError('Expected message');
+      }).not.toThrowWithMessage(TypeError, /Expected message/)
+    ).toThrowErrorMatchingSnapshot();
   });
 });


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/173.

> ### What
> During the initial implementation of `toThrowWithMessage` I forgot to handle the `.not` during validation. As such, when a user uses `.not`, validation doesn't work at all.
> 
> ### Why
> The matcher won't correctly validate `.not` cases.
> 
> ### Notes
> ### Housekeeping
> * [x]  Unit tests
> * [x]  Documentation is up to date
> * [x]  No additional lint warnings
> * [x]  Add yourself to contributors list (`yarn contributor`)
> * [x]  [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant