### PR TITLE
Make fail() to break the typescript's control flow

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,7 +17,7 @@ declare namespace jest {
      *
      * @param {String} message
      */
-    fail(message: string): R;
+    fail(message: string): never;
 
     /**
      * Use .toBeEmpty when checking if a String '', Array [], Object {} or Iterable (i.e. Map, Set) is empty.


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/312.

> Imagine we have a code like this. If `expect.fail()` returns `R`, we won't be able to call `val.slice` as `val` may be `null`, thus we get a compiler error.
> 
> ```ts
>     test('example', async () => {
>       const val = foo() // string | null
>       if (!val) expect.fail('string expected, got null')
>       
>       val.slice(5) // some operations with the string
>       // ...
>     })
> ```
> 
> Though, if we change `expect.fail()` return type to `never`, typescript will start understanding the further execution won't be possible with `val === null`, so the `val.slice` is exactly `string::slice` call. And there won't be any compilation errors.