### PR TITLE
[Docs]: made badge point to the contributing guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![version](https://img.shields.io/npm/v/jest-extended.svg?style=flat-square)](https://www.npmjs.com/package/jest-extended)
 [![downloads](https://img.shields.io/npm/dm/jest-extended.svg?style=flat-square)](http://npm-stat.com/charts.html?package=jest-extended&from=2017-09-14)
 [![MIT License](https://img.shields.io/npm/l/jest-extended.svg?style=flat-square)](https://github.com/jest-community/jest-extended/blob/master/LICENSE)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](./CONTRIBUTING.md)
 [![Roadmap](https://img.shields.io/badge/%F0%9F%93%94-roadmap-CD9523.svg?style=flat-square)](https://github.com/jest-community/jest-extended/blob/master/docs/ROADMAP.md)
 [![Examples](https://img.shields.io/badge/%F0%9F%92%A1-examples-ff615b.svg?style=flat-square)](https://github.com/jest-community/jest-extended/blob/master/docs/EXAMPLES.md)
 


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/259.

> ### What
> Made the PR welcoming badge point to the contributing guidelines.
> 
> ### Why
> It definitely makes much sense to link up to the contributing docs rather than the badge source.
> 
> ### Notes
> ### Housekeeping
> * [ ]  Unit tests
> * [x]  Documentation is up to date
> * [x]  No additional lint warnings
> * [ ]  [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant