### PR TITLE
fix(toCotainKeys): should not throw when actual is undefied

### DIFF
--- a/src/matchers/toContainKeys/predicate.js
+++ b/src/matchers/toContainKeys/predicate.js
@@ -1,1 +1,1 @@
-export default (obj, keys) => keys.every(key => obj.hasOwnProperty && obj.hasOwnProperty(key));
+export default (obj, keys) => keys.every(key => obj && obj.hasOwnProperty && obj.hasOwnProperty(key));

--- a/src/matchers/toContainKeys/predicate.test.js
+++ b/src/matchers/toContainKeys/predicate.test.js
@@ -10,4 +10,10 @@ describe('.toContainKeys', () => {
   test('fails when object does not contain all keys', () => {
     expect(predicate(data, ['d'])).toBe(false);
   });
+
+  test('does not throw when object is undefined', () => {
+    expect(() => {
+      predicate(undefined, ['d']);
+    }).not.toThrow("Cannot read property 'hasOwnProperty' of undefined");
+  });
 });


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/295.

> ### What
> Bug.
> 
> ### Why
> `expect.toContainKeys` throws when `actual` is `undefined`.
> 
> **Reproduction steps**
> 
> ```js
> expect({}).toEqual({
>     expectedObject: expect.toContainKeys(["expectedProperty"]),
> });
> ```
> 
> **Actual behavior**
> 
> An error is thrown.
> 
> <img alt="Screenshot 2020-09-06 at 13 47 02" width="580" src="https://user-images.githubusercontent.com/35487738/92325243-4f2f4c00-f049-11ea-8a02-0dad1f5c226a.png">
> 
> **Expected behavior**
> 
> Displaying actual/expected diff.
> 
> <img alt="Screenshot 2020-09-06 at 13 47 23" width="427" src="https://user-images.githubusercontent.com/35487738/92325213-11cabe80-f049-11ea-829a-b849ff4f9dfb.png">
> 
> ### Notes
> ### Housekeeping
> * [x]  Unit tests
> * [ ]  Documentation is up to date
> * [ ]  No additional lint warnings
> * [ ]  [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant