### PR TITLE
improved toResolve feedback by including error in the message

### DIFF
--- a/src/matchers/toResolve/__snapshots__/index.test.js.snap
+++ b/src/matchers/toResolve/__snapshots__/index.test.js.snap
@@ -13,3 +13,13 @@ exports[`.toResolve fails when passed a promise that rejects 1`] = `
 Expected promise to resolve, however it rejected.
 "
 `;
+
+exports[`.toResolve fails when passed a promise that rejects with an error object 1`] = `
+"<dim>expect(</><red>received</><dim>).toResolve(</><dim>)</>
+
+Expected promise to resolve, however it rejected.
+
+
+Error:
+Error"
+`;

--- a/src/matchers/toResolve/index.js
+++ b/src/matchers/toResolve/index.js
@@ -5,15 +5,21 @@ import predicate from './predicate';
 const passMessage = () =>
   matcherHint('.not.toResolve', 'received', '') + '\n\n' + 'Expected promise to reject, however it resolved.\n';
 
-const failMessage = () =>
-  matcherHint('.toResolve', 'received', '') + '\n\n' + 'Expected promise to resolve, however it rejected.\n';
+const failMessage = error => () => {
+  const base =
+    matcherHint('.toResolve', 'received', '') + '\n\n' + 'Expected promise to resolve, however it rejected.\n';
+  if (error === undefined) {
+    return base;
+  }
+  return base + '\n\n' + 'Error:\n' + error;
+};
 
 export default {
   toResolve: async promise => {
-    const pass = await predicate(promise);
+    const { pass, error } = await predicate(promise);
     if (pass) {
       return { pass: true, message: passMessage };
     }
-    return { pass: false, message: failMessage };
+    return { pass: false, message: failMessage(error) };
   }
 };

--- a/src/matchers/toResolve/index.test.js
+++ b/src/matchers/toResolve/index.test.js
@@ -12,6 +12,11 @@ describe('.toResolve', () => {
     const promise = Promise.reject();
     await expect(expect(promise).toResolve()).rejects.toThrowErrorMatchingSnapshot();
   });
+
+  test('fails when passed a promise that rejects with an error object', async () => {
+    const promise = Promise.reject(new Error());
+    await expect(expect(promise).toResolve()).rejects.toThrowErrorMatchingSnapshot();
+  });
 });
 
 describe('.not.toResolve', () => {
@@ -22,6 +27,11 @@ describe('.not.toResolve', () => {
 
   test('passes when passed a promise that rejects', async () => {
     const promise = Promise.reject();
+    await expect(promise).not.toResolve();
+  });
+
+  test('fails when passed a promise that rejects with an error object', async () => {
+    const promise = Promise.reject(new Error());
     await expect(promise).not.toResolve();
   });
 });

--- a/src/matchers/toResolve/predicate.js
+++ b/src/matchers/toResolve/predicate.js
@@ -1,1 +1,8 @@
-export default promise => promise.then(() => true, () => false);
+export default async promise => {
+  try {
+    await promise;
+    return { pass: true };
+  } catch (error) {
+    return { pass: false, error };
+  }
+};

--- a/src/matchers/toResolve/predicate.test.js
+++ b/src/matchers/toResolve/predicate.test.js
@@ -1,13 +1,14 @@
 import predicate from './predicate';
 
 describe('toResolve predicate', () => {
-  test('should return true when passed a promise that resolves', async () => {
+  test('should return undefined when passed a promise that resolves', async () => {
     const promise = Promise.resolve();
-    expect(await predicate(promise)).toBe(true);
+    expect(await predicate(promise)).toStrictEqual({ pass: true });
   });
 
-  test('should return false when passed a promise that rejects', async () => {
-    const promise = Promise.reject();
-    expect(await predicate(promise)).toBe(false);
+  test('should resolve with the error when passed a promise that rejects', async () => {
+    const error = new Error();
+    const promise = Promise.reject(error);
+    expect(await predicate(promise)).toStrictEqual({ pass: false, error });
   });
 });


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/296.

> ### What
> Improving the feedback when the `toResolve` assertion fails.
> 
> ### Why
> Currently, the feedback from `toResolve` is not great. It generates the following message: `Expected promise to resolve, however it rejected.`. There is no indication regarding why the assertion failed.
> 
> ### Notes
> ### Housekeeping
> * [x]  Unit tests
> * [x]  Documentation is up to date
> * [x]  No additional lint warnings
> * [x]  [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant