### PR TITLE
Allow any iterable in toInclude*Members

### DIFF
--- a/src/matchers/toIncludeAllMembers/__snapshots__/index.test.js.snap
+++ b/src/matchers/toIncludeAllMembers/__snapshots__/index.test.js.snap
@@ -9,16 +9,7 @@ Received:
   <red>[1, 2, 3]</>"
 `;
 
-exports[`.toIncludeAllMembers fails when array values do not contain any of the members of the set 1`] = `
-"<dim>expect(</><red>received</><dim>).toIncludeAllMembers(</><green>expected</><dim>)</>
-
-Expected list to have all of the following members:
-  <green>[1, 2, 3]</>
-Received:
-  <red>[4, 5, 6]</>"
-`;
-
-exports[`.toIncludeAllMembers fails when expected object is not an array 1`] = `
+exports[`.toIncludeAllMembers fails when expected object is not an iterable 1`] = `
 "<dim>expect(</><red>received</><dim>).toIncludeAllMembers(</><green>expected</><dim>)</>
 
 Expected list to have all of the following members:
@@ -27,11 +18,29 @@ Received:
   <red>[1, 2, 3]</>"
 `;
 
-exports[`.toIncludeAllMembers fails when given object is not an array 1`] = `
+exports[`.toIncludeAllMembers fails when given object is not an iterable 1`] = `
 "<dim>expect(</><red>received</><dim>).toIncludeAllMembers(</><green>expected</><dim>)</>
 
 Expected list to have all of the following members:
   <green>[1, 2, 3]</>
 Received:
   <red>2</>"
+`;
+
+exports[`.toIncludeAllMembers fails when iterable values do not contain any of the members of the set 1`] = `
+"<dim>expect(</><red>received</><dim>).toIncludeAllMembers(</><green>expected</><dim>)</>
+
+Expected list to have all of the following members:
+  <green>[1, 2, 3]</>
+Received:
+  <red>[4, 5, 6]</>"
+`;
+
+exports[`.toIncludeAllMembers fails when iterable values do not contain any of the members of the set 2`] = `
+"<dim>expect(</><red>received</><dim>).toIncludeAllMembers(</><green>expected</><dim>)</>
+
+Expected list to have all of the following members:
+  <green>[1, 2, 3]</>
+Received:
+  <red>Set {4, 5, 6}</>"
 `;

--- a/src/matchers/toIncludeAllMembers/index.test.js
+++ b/src/matchers/toIncludeAllMembers/index.test.js
@@ -6,21 +6,25 @@ describe('.toIncludeAllMembers', () => {
   const array1 = [1, 2, 3];
   const array2 = [1, 2, 2];
 
-  test('passes when array values matches the members of the set', () => {
+  test('passes when iterable values matches the members of the set', () => {
     expect(array1).toIncludeAllMembers([2, 1, 3]);
     expect(array2).toIncludeAllMembers([2, 1]);
+    expect(new Set(array1)).toIncludeAllMembers([2, 1, 3]);
+    expect(new Set(array2)).toIncludeAllMembers([2, 1]);
+
     expect([{ foo: 'bar' }, { baz: 'qux' }]).toIncludeAllMembers([{ foo: 'bar' }]);
   });
 
-  test('fails when array values do not contain any of the members of the set', () => {
+  test('fails when iterable values do not contain any of the members of the set', () => {
     expect(() => expect([4, 5, 6]).toIncludeAllMembers([1, 2, 3])).toThrowErrorMatchingSnapshot();
+    expect(() => expect(new Set([4, 5, 6])).toIncludeAllMembers([1, 2, 3])).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when given object is not an array', () => {
+  test('fails when given object is not an iterable', () => {
     expect(() => expect(2).toIncludeAllMembers([1, 2, 3])).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when expected object is not an array', () => {
+  test('fails when expected object is not an iterable', () => {
     expect(() => expect(array1).toIncludeAllMembers(2)).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toIncludeAllMembers/predicate.js
+++ b/src/matchers/toIncludeAllMembers/predicate.js
@@ -1,5 +1,8 @@
-import { contains } from '../../utils';
+import { asArray, contains } from '../../utils';
 
-export default (array, set) => {
-  return Array.isArray(array) && Array.isArray(set) && set.every(val => contains(array, val));
+export default (iterable, members) => {
+  const first = asArray(iterable);
+  const second = first && asArray(members);
+
+  return first != null && second != null && second.every(val => contains(first, val));
 };

--- a/src/matchers/toIncludeAllMembers/predicate.test.js
+++ b/src/matchers/toIncludeAllMembers/predicate.test.js
@@ -7,22 +7,28 @@ describe('toIncludeAllMembers Predicate', () => {
   const set2 = [1, 2, 3];
 
   describe('returns true', () => {
-    test('when Array contains all the same members of given set', () => {
+    test('when iterable contains all the same members of given set', () => {
       expect(predicate(array1, set1)).toBe(true);
+      expect(predicate(new Set(array1), set1)).toBe(true);
+      expect(predicate(new Set(array1), new Set(set1))).toBe(true);
     });
 
-    test('when Array contains all of the same nested members of given set', () => {
+    test('when iterable contains all of the same nested members of given set', () => {
       expect(predicate([{ hello: 'world' }, { foo: 'bar' }], [{ foo: 'bar' }])).toBe(true);
+      expect(predicate(new Set([{ hello: 'world' }, { foo: 'bar' }]), [{ foo: 'bar' }])).toBe(true);
     });
   });
 
   describe('returns false', () => {
-    test('when Array does not contain any of the members of given set', () => {
+    test('when iterable does not contain any of the members of given set', () => {
       expect(predicate(array2, set2)).toBe(false);
+      expect(predicate(new Set(array2), set2)).toBe(false);
+      expect(predicate(new Set(array2), new Set(set2))).toBe(false);
     });
 
-    test('when Array contains does not contain all of the same nested members of given set', () => {
+    test('when iterable contains does not contain all of the same nested members of given set', () => {
       expect(predicate([{ hello: 'world' }, { foo: 'bar' }], [{ foo: 'qux' }])).toBe(false);
+      expect(predicate(new Set([{ hello: 'world' }, { foo: 'bar' }]), new Set([{ foo: 'qux' }]))).toBe(false);
     });
   });
 });

--- a/src/matchers/toIncludeAnyMembers/__snapshots__/index.test.js.snap
+++ b/src/matchers/toIncludeAnyMembers/__snapshots__/index.test.js.snap
@@ -9,6 +9,15 @@ Received:
   <red>[[{\\"hello\\": \\"world\\"}]]</>"
 `;
 
+exports[`.not.toIncludeAnyMembers fails when given array contains array value 2`] = `
+"<dim>expect(</><red>received</><dim>).not.toIncludeAnyMembers(</><green>expected</><dim>)</>
+
+Expected list to not include any of the following members:
+  <green>[[{\\"hello\\": \\"world\\"}], 7]</>
+Received:
+  <red>Set {[{\\"hello\\": \\"world\\"}]}</>"
+`;
+
 exports[`.not.toIncludeAnyMembers fails when given array contains object value 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toIncludeAnyMembers(</><green>expected</><dim>)</>
 
@@ -16,6 +25,15 @@ Expected list to not include any of the following members:
   <green>[{\\"foo\\": \\"bar\\"}]</>
 Received:
   <red>[{\\"foo\\": \\"bar\\"}]</>"
+`;
+
+exports[`.not.toIncludeAnyMembers fails when given array contains object value 2`] = `
+"<dim>expect(</><red>received</><dim>).not.toIncludeAnyMembers(</><green>expected</><dim>)</>
+
+Expected list to not include any of the following members:
+  <green>[{\\"foo\\": \\"bar\\"}]</>
+Received:
+  <red>Set {{\\"foo\\": \\"bar\\"}}</>"
 `;
 
 exports[`.not.toIncludeAnyMembers fails when given object contains primitive value 1`] = `
@@ -27,6 +45,15 @@ Received:
   <red>[7]</>"
 `;
 
+exports[`.not.toIncludeAnyMembers fails when given object contains primitive value 2`] = `
+"<dim>expect(</><red>received</><dim>).not.toIncludeAnyMembers(</><green>expected</><dim>)</>
+
+Expected list to not include any of the following members:
+  <green>[7, 8]</>
+Received:
+  <red>Set {7}</>"
+`;
+
 exports[`.toIncludeAnyMembers fails when expected object does not contain array value 1`] = `
 "<dim>expect(</><red>received</><dim>).toIncludeAnyMembers(</><green>expected</><dim>)</>
 
@@ -36,7 +63,7 @@ Received:
   <red>[1, 2, 3]</>"
 `;
 
-exports[`.toIncludeAnyMembers fails when given array does not contain any members  1`] = `
+exports[`.toIncludeAnyMembers fails when given iterables does not contain any members  1`] = `
 "<dim>expect(</><red>received</><dim>).toIncludeAnyMembers(</><green>expected</><dim>)</>
 
 Expected list to include any of the following members:
@@ -45,7 +72,16 @@ Received:
   <red>[4, 5, 6]</>"
 `;
 
-exports[`.toIncludeAnyMembers fails when given object is not an array 1`] = `
+exports[`.toIncludeAnyMembers fails when given iterables does not contain any members  2`] = `
+"<dim>expect(</><red>received</><dim>).toIncludeAnyMembers(</><green>expected</><dim>)</>
+
+Expected list to include any of the following members:
+  <green>[1, 2, 3]</>
+Received:
+  <red>Set {4, 5, 6}</>"
+`;
+
+exports[`.toIncludeAnyMembers fails when given object is not an iterable 1`] = `
 "<dim>expect(</><red>received</><dim>).toIncludeAnyMembers(</><green>expected</><dim>)</>
 
 Expected list to include any of the following members:

--- a/src/matchers/toIncludeAnyMembers/index.test.js
+++ b/src/matchers/toIncludeAnyMembers/index.test.js
@@ -6,23 +6,27 @@ describe('.toIncludeAnyMembers', () => {
   const shallow = { hello: 'world' };
   const deep = { message: shallow };
 
-  test('passes when given array is a subset', () => {
+  test('passes when given iterable is a subset', () => {
     expect([2, 3]).toIncludeAnyMembers([1, 2, 3]);
+    expect(new Set([2, 3])).toIncludeAnyMembers([1, 2, 3]);
   });
 
   test('passes when given array contains some of the members', () => {
     expect([1, 2, 3]).toIncludeAnyMembers([2, 3, 4]);
+    expect(new Set([1, 2, 3])).toIncludeAnyMembers([2, 3, 4]);
   });
 
   test('passes when given array contains object value', () => {
     expect([shallow]).toIncludeAnyMembers([shallow, deep]);
+    expect(new Set([shallow])).toIncludeAnyMembers([shallow, deep]);
   });
 
-  test('fails when given array does not contain any members ', () => {
+  test('fails when given iterables does not contain any members ', () => {
     expect(() => expect([4, 5, 6]).toIncludeAnyMembers([1, 2, 3])).toThrowErrorMatchingSnapshot();
+    expect(() => expect(new Set([4, 5, 6])).toIncludeAnyMembers([1, 2, 3])).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when given object is not an array', () => {
+  test('fails when given object is not an iterable', () => {
     expect(() => expect(7).toIncludeAnyMembers([1, 2, 3])).toThrowErrorMatchingSnapshot();
   });
 
@@ -36,10 +40,12 @@ describe('.not.toIncludeAnyMembers', () => {
 
   test('passes when given array does not contain primitive value', () => {
     expect(['hola', 'mundo']).not.toIncludeAnyMembers(['hello', 'world']);
+    expect(new Set(['hola', 'mundo'])).not.toIncludeAnyMembers(['hello', 'world']);
   });
 
   test('passes when given array does not contain object value', () => {
     expect([{ hello: 'world' }]).not.toIncludeAnyMembers([{ world: 'hello' }]);
+    expect(new Set([{ hello: 'world' }])).not.toIncludeAnyMembers([{ world: 'hello' }]);
   });
 
   test('passes when given object is not array', () => {
@@ -48,13 +54,18 @@ describe('.not.toIncludeAnyMembers', () => {
 
   test('fails when given object contains primitive value', () => {
     expect(() => expect([7]).not.toIncludeAnyMembers([7, 8])).toThrowErrorMatchingSnapshot();
+    expect(() => expect(new Set([7])).not.toIncludeAnyMembers([7, 8])).toThrowErrorMatchingSnapshot();
   });
 
   test('fails when given array contains object value', () => {
     expect(() => expect([{ foo: 'bar' }]).not.toIncludeAnyMembers([{ foo: 'bar' }])).toThrowErrorMatchingSnapshot();
+    expect(() =>
+      expect(new Set([{ foo: 'bar' }])).not.toIncludeAnyMembers([{ foo: 'bar' }])
+    ).toThrowErrorMatchingSnapshot();
   });
 
   test('fails when given array contains array value', () => {
     expect(() => expect([[shallow]]).not.toIncludeAnyMembers([[shallow], 7])).toThrowErrorMatchingSnapshot();
+    expect(() => expect(new Set([[shallow]])).not.toIncludeAnyMembers([[shallow], 7])).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toIncludeAnyMembers/predicate.js
+++ b/src/matchers/toIncludeAnyMembers/predicate.js
@@ -1,5 +1,8 @@
-import { contains } from '../../utils';
+import { asArray, contains } from '../../utils';
 
-export default (array, members) => {
-  return Array.isArray(array) && Array.isArray(members) && members.some(member => contains(array, member));
+export default (iterable, members) => {
+  const first = asArray(iterable);
+  const second = first && asArray(members);
+
+  return first != null && second != null && second.some(val => contains(first, val));
 };

--- a/src/matchers/toIncludeAnyMembers/predicate.test.js
+++ b/src/matchers/toIncludeAnyMembers/predicate.test.js
@@ -10,29 +10,37 @@ describe('toIncludeAnyMembers Predicate', () => {
       'when given array contains primitive value: %s',
       given => {
         expect(predicate([given], array)).toBe(true);
+        expect(predicate(new Set([given]), array)).toBe(true);
+        expect(predicate(new Set([given]), new Set(array))).toBe(true);
       }
     );
 
     test('when given array contains object value', () => {
       expect(predicate([shallow, 7], [shallow])).toBe(true);
+      expect(predicate(new Set([shallow, 7]), [shallow])).toBe(true);
     });
 
     test('when given object contains array value', () => {
       expect(predicate([[shallow]], [[shallow], 7])).toBe(true);
+      expect(predicate(new Set([[shallow]]), [[shallow], 7])).toBe(true);
     });
   });
 
   describe('returns false', () => {
     test('when given array does not contain primitive value', () => {
       expect(predicate([3, 4, 5], [1])).toBe(false);
+      expect(predicate(new Set([3, 4, 5]), [1])).toBe(false);
+      expect(predicate(new Set([3, 4, 5]), new Set([1]))).toBe(false);
     });
 
     test('when given array does not contain object value', () => {
       expect(predicate([3], [{ foo: 'bar' }])).toBe(false);
+      expect(predicate(new Set([3]), [{ foo: 'bar' }])).toBe(false);
     });
 
     test('when given object does not contain array value', () => {
       expect(predicate([7], [[7]])).toBe(false);
+      expect(predicate(new Set([7]), [[7]])).toBe(false);
     });
   });
 });

--- a/src/matchers/toIncludeSameMembers/__snapshots__/index.test.js.snap
+++ b/src/matchers/toIncludeSameMembers/__snapshots__/index.test.js.snap
@@ -9,11 +9,29 @@ Received:
   <red>[1]</>"
 `;
 
-exports[`.toIncludeSameMembers fails when the arrays are not equal in length 1`] = `
+exports[`.not.toIncludeSameMembers fails when array contents match 2`] = `
+"<dim>expect(</><red>received</><dim>).not.toIncludeSameMembers(</><green>expected</><dim>)</>
+
+Expected list to not exactly match the members of:
+  <green>[1]</>
+Received:
+  <red>Set {1}</>"
+`;
+
+exports[`.toIncludeSameMembers fails when the iterables are not equal in length 1`] = `
 "<dim>expect(</><red>received</><dim>).toIncludeSameMembers(</><green>expected</><dim>)</>
 
 Expected list to have the following members and no more:
   <green>[1]</>
 Received:
   <red>[1, 2]</>"
+`;
+
+exports[`.toIncludeSameMembers fails when the iterables are not equal in length 2`] = `
+"<dim>expect(</><red>received</><dim>).toIncludeSameMembers(</><green>expected</><dim>)</>
+
+Expected list to have the following members and no more:
+  <green>[1, 2, 2]</>
+Received:
+  <red>Set {1, 2}</>"
 `;

--- a/src/matchers/toIncludeSameMembers/index.test.js
+++ b/src/matchers/toIncludeSameMembers/index.test.js
@@ -5,41 +5,53 @@ expect.extend(matcher);
 describe('.toIncludeSameMembers', () => {
   test('passes when arrays are empty', () => {
     expect([]).toIncludeSameMembers([]);
+    expect(new Set()).toIncludeSameMembers([]);
   });
 
   test('passes when arrays match', () => {
     expect([1, 2, 3]).toIncludeSameMembers([1, 2, 3]);
+    expect(new Set([1, 2, 3])).toIncludeSameMembers([1, 2, 3]);
     expect([{ foo: 'bar' }, { baz: 'qux' }]).toIncludeSameMembers([{ foo: 'bar' }, { baz: 'qux' }]);
+    expect(new Set([{ foo: 'bar' }, { baz: 'qux' }])).toIncludeSameMembers([{ foo: 'bar' }, { baz: 'qux' }]);
   });
 
   test('passes when arrays match in a different order', () => {
     expect([1, 2, 3]).toIncludeSameMembers([3, 1, 2]);
+    expect(new Set([1, 2, 3])).toIncludeSameMembers([3, 1, 2]);
     expect([{ foo: 'bar' }, { baz: 'qux' }]).toIncludeSameMembers([{ baz: 'qux' }, { foo: 'bar' }]);
   });
 
-  test('fails when the arrays are not equal in length', () => {
+  test('fails when the iterables are not equal in length', () => {
     expect(() => expect([1, 2]).toIncludeSameMembers([1])).toThrowErrorMatchingSnapshot();
+    expect(() => expect(new Set([1, 2])).toIncludeSameMembers([1, 2, 2])).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toIncludeSameMembers', () => {
   test('fails when array contents match', () => {
     expect(() => expect([1]).not.toIncludeSameMembers([1])).toThrowErrorMatchingSnapshot();
+    expect(() => expect(new Set([1])).not.toIncludeSameMembers([1])).toThrowErrorMatchingSnapshot();
   });
 
   test('passes when the arrays are different in length', () => {
     expect([1, 2, 3]).not.toIncludeSameMembers([1, 2]);
+    expect(new Set([1, 2])).not.toIncludeSameMembers([1, 2, 3]);
     expect([{ foo: 'bar' }, { baz: 'qux' }]).not.toIncludeSameMembers([{ hello: 'world' }]);
   });
 
-  test('passes when given object is not an array', () => {
+  test('passes when given object is not an iterable', () => {
     expect(4).not.toIncludeSameMembers([4, 5, 6]);
   });
 
-  test('passes when arrays do not match', () => {
+  test('passes when iterables do not match', () => {
     expect([]).not.toIncludeSameMembers([1]);
     expect([1]).not.toIncludeSameMembers([1, 1]);
     expect([1, 2]).not.toIncludeSameMembers([1, 2, 2]);
     expect([1, 2, 3]).not.toIncludeSameMembers([2, 3, 4]);
+
+    expect(new Set([])).not.toIncludeSameMembers([1]);
+    expect(new Set([1])).not.toIncludeSameMembers([1, 1]);
+    expect(new Set([1, 2])).not.toIncludeSameMembers([1, 2, 2]);
+    expect(new Set([1, 2, 3])).not.toIncludeSameMembers([2, 3, 4]);
   });
 });

--- a/src/matchers/toIncludeSameMembers/predicate.js
+++ b/src/matchers/toIncludeSameMembers/predicate.js
@@ -1,4 +1,4 @@
-import { equals } from '../../utils';
+import { asArray, equals } from '../../utils';
 
 const filterMatches = (first, second) =>
   second.reduce((remaining, secondValue) => {
@@ -13,10 +13,11 @@ const filterMatches = (first, second) =>
     return remaining.slice(0, index).concat(remaining.slice(index + 1));
   }, first);
 
-export default (first, second) => {
-  if (!Array.isArray(first) || !Array.isArray(second) || first.length !== second.length) {
-    return false;
-  }
+export default (iterable, members) => {
+  const first = asArray(iterable);
+  const second = first && asArray(members);
+
+  if (first == null || second == null || first.length !== second.length) return false;
 
   const remaining = filterMatches(first, second);
 

--- a/src/matchers/toIncludeSameMembers/predicate.test.js
+++ b/src/matchers/toIncludeSameMembers/predicate.test.js
@@ -1,16 +1,20 @@
 import predicate from './predicate';
 
 describe('toIncludeSameMembers Predicate', () => {
-  test('returns true when arrays are empty', () => {
+  test('returns true when iterables  are empty', () => {
     expect(predicate([], [])).toBe(true);
+    expect(predicate(new Set(), [])).toBe(true);
+    expect(predicate([], new Set())).toBe(true);
   });
 
   test('returns true when arrays match with the same order', () => {
     expect(predicate([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(predicate(new Set([1, 2, 3]), [1, 2, 3])).toBe(true);
   });
 
   test('returns true when arrays match with reverse order', () => {
     expect(predicate([1, 2, 3], [3, 2, 1])).toBe(true);
+    expect(predicate(new Set([1, 2, 3]), [3, 2, 1])).toBe(true);
   });
 
   test('returns true when arrays match with duplicate elements and same order', () => {
@@ -21,7 +25,7 @@ describe('toIncludeSameMembers Predicate', () => {
     expect(predicate([1, 2, 2], [2, 2, 1])).toBe(true);
   });
 
-  test('returns false when inputs are not arrays', () => {
+  test('returns false when inputs are not iterables', () => {
     expect(predicate(null, null)).toBe(false);
     expect(predicate(null, [])).toBe(false);
     expect(predicate([], null)).toBe(false);
@@ -31,23 +35,31 @@ describe('toIncludeSameMembers Predicate', () => {
     expect(predicate([], [1])).toBe(false);
     expect(predicate([1], [])).toBe(false);
     expect(predicate([1, 2, 3], [1, 2])).toBe(false);
+    expect(predicate(new Set([1, 2]), [1, 2, 2])).toBe(false);
   });
 
   test('returns false when no elements match', () => {
     expect(predicate([1, 2], [3, 4])).toBe(false);
+    expect(predicate(new Set([1, 2]), [3, 4])).toBe(false);
   });
 
   test('returns false when only one element matches', () => {
     expect(predicate([1, 2, 3], [3, 4, 5])).toBe(false);
+    expect(predicate(new Set([1, 2, 3]), [3, 4, 5])).toBe(false);
   });
 
   test('returns false when all but one element matches', () => {
     expect(predicate([1, 2, 3], [2, 3, 4])).toBe(false);
+    expect(predicate(new Set([1, 2, 3]), [2, 3, 4])).toBe(false);
   });
 
-  test('does not modify the array content', () => {
+  test('does not modify the iterable content', () => {
     const arr = [1, 2, 3];
     predicate(arr, arr);
     expect(arr).toEqual([1, 2, 3]);
+
+    const set = new Set([1, 2, 3]);
+    predicate(set, set);
+    expect([...set]).toEqual([1, 2, 3]);
   });
 });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,12 @@
 import { equals } from 'expect/build/jasmineUtils';
 
+export const asArray = value => {
+  if (Array.isArray(value)) return value;
+  if (value != null && typeof value[Symbol.iterator] === 'function') return [...value];
+
+  return undefined;
+};
+
 export const contains = (list, value) => {
   return list.findIndex(item => equals(item, value)) > -1;
 };

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -1,6 +1,6 @@
 import each from 'jest-each';
 
-import { contains, determinePropertyMessage } from './';
+import { asArray, contains, determinePropertyMessage } from './';
 
 describe('Utils', () => {
   describe('.contains', () => {
@@ -14,6 +14,31 @@ describe('Utils', () => {
 
     each(testRows).test('returns false when array does not contain given value: %s', value => {
       expect(contains([], value)).toBe(false);
+    });
+  });
+
+  describe('.asArray', () => {
+    test('returns the argument when given an array', () => {
+      const array = [1, 2, 3];
+
+      expect(asArray(array)).toBe(array);
+    });
+
+    test('returns a new array when given a non-array iterable', () => {
+      const set = new Set([1, 2, 3]);
+      const array = asArray(set);
+
+      expect(array).toBeInstanceOf(Array);
+      expect(array).toHaveLength(3);
+      expect(array).toContain(1);
+      expect(array).toContain(2);
+      expect(array).toContain(3);
+    });
+
+    test('returns undefined when given a non-iterable', () => {
+      expect(asArray(true)).toBeUndefined();
+      expect(asArray(123)).toBeUndefined();
+      expect(asArray({})).toBeUndefined();
     });
   });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -65,22 +65,22 @@ declare namespace jest {
     toBeBefore(date: Date): R;
 
     /**
-     * Use `.toIncludeAllMembers` when checking if an `Array` contains all of the same members of a given set.
-     * @param {Array.<*>} members
+     * Use `.toIncludeAllMembers` when checking if an `Iterable` contains all of the same members of a given set.
+     * @param {Iterable.<*>} members
      */
-    toIncludeAllMembers(members: any[]): R;
+    toIncludeAllMembers(members: Iterable<any>): R;
 
     /**
-     * Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.
-     * @param {Array.<*>} members
+     * Use `.toIncludeAnyMembers` when checking if an `Iterable` contains any of the members of a given set.
+     * @param {Iterable.<*>} members
      */
-    toIncludeAnyMembers(members: any[]): R;
+    toIncludeAnyMembers(members: Iterable<any>): R;
 
     /**
-     * Use `.toIncludeSameMembers` when checking if two arrays contain equal values, in any order.
-     * @param {Array.<*>} members
+     * Use `.toIncludeSameMembers` when checking if two `Iterable`s contain equal values, in any order.
+     * @param {Iterable.<*>} members
      */
-    toIncludeSameMembers(members: any[]): R;
+    toIncludeSameMembers(members: Iterable<any>): R;
 
     /**
      * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
@@ -421,22 +421,22 @@ declare namespace jest {
     toBeBefore(date: Date): any;
 
     /**
-     * Use `.toIncludeAllMembers` when checking if an `Array` contains all of the same members of a given set.
-     * @param {Array.<*>} members
+     * Use `.toIncludeAllMembers` when checking if an `Iterable` contains all of the same members of a given set.
+     * @param {Iterable.<*>} members
      */
-    toIncludeAllMembers(members: any[]): any;
+    toIncludeAllMembers(members: Iterable<any>): any;
 
     /**
-     * Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.
-     * @param {Array.<*>} members
+     * Use `.toIncludeAnyMembers` when checking if an `Iterable` contains any of the members of a given set.
+     * @param {Iterable.<*>} members
      */
-    toIncludeAnyMembers(members: any[]): any;
+    toIncludeAnyMembers(members: Iterable<any>): any;
 
     /**
-     * Use `.toIncludeSameMembers` when checking if two arrays contain equal values, in any order.
-     * @param {Array.<*>} members
+     * Use `.toIncludeSameMembers` when checking if two `Iterable`s contain equal values, in any order.
+     * @param {Iterable.<*>} members
      */
-    toIncludeSameMembers(members: any[]): any;
+    toIncludeSameMembers(members: Iterable<any>): any;
 
     /**
      * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/298.

> ### What
> Modifies the three `toInclude{All,Any,Some}Members` matchers to also match on iterables.
> 
> ### Why
> This is meant mostly for testing things that return `Set` and `Map` instances, but it’s generally useful for any Iterable.
> 
> ### Notes
> I’m not sure exactly what’s wrong with the typing file, I get `TS2304: Cannot find name 'Iterable'.` errors.
> 
> ### Housekeeping
> * [x]  Unit tests
> * [x]  Documentation is up to date
> * [x]  No additional lint warnings
> * [x]  [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant