### PR TITLE
Created toBeWithinPercent and toContainKeysWithinPercent

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ If you've come here to help contribute - Thanks! Take a look at the [contributin
     - [.toBeEven()](#tobeeven)
     - [.toBeOdd()](#tobeodd)
     - [.toBeWithin(start, end)](#tobewithinstart-end)
+    - [.toBeWithinPercent(mid, percent)](#tobewithinpercentmid-percent)
   - [Object](#object)
     - [.toBeObject()](#tobeobject)
     - [.toContainKey(key)](#tocontainkeykey)
@@ -596,6 +597,18 @@ test('passes when number is within given bounds', () => {
   expect(1).toBeWithin(1, 3);
   expect(2).toBeWithin(1, 3);
   expect(3).not.toBeWithin(1, 3);
+});
+```
+
+#### .toBeWithinPercent(mid, percent)
+
+Use `.toBeWithinPercent` when checking if a number is within x percent of a midpoint number.
+
+```js
+test('passes when number is within x percent of mid', () => {
+  expect(55).toBeWithinPercent(50, 10);
+  expect(20).toBeWithinPercent(10, 100);
+  expect(100).not.toBeWithinPercent(10, 5);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -602,10 +602,10 @@ test('passes when number is within given bounds', () => {
 
 #### .toBeWithinPercent(mid, percent)
 
-Use `.toBeWithinPercent` when checking if a number is within x percent of a midpoint number.
+Use `.toBeWithinPercent` when checking if a number is within x percent of a target number.
 
 ```js
-test('passes when number is within x percent of mid', () => {
+test('passes when number is within x percent of target', () => {
   expect(55).toBeWithinPercent(50, 10);
   expect(20).toBeWithinPercent(10, 100);
   expect(100).not.toBeWithinPercent(10, 5);

--- a/README.md
+++ b/README.md
@@ -653,6 +653,25 @@ test('passes when object contains all keys', () => {
 });
 ```
 
+#### .toContainKeysWithinPercent([keyObjects])
+
+Use `.toContainKeysWithinPercent` when checking if an object has all of the provided keys and that the value of these keys is within x percent of a target value.
+
+```js
+test('passes when object contains all keys', () => {
+  const data1 = { a: 55, b: 1 };
+  const data2 = { a: 45, b: 1 }
+  const data3 = { a: 20, b: 2 }
+  const data4 = { a: 50 }
+  const keys = [{key: "a", target: 50, percent: 10}, {key: "b", target: 1, percent: 0}]
+
+  expect(data1).toContainKeysWithinPercent(keys);
+  expect(data2).toContainKeysWithinPercent(keys);
+  expect(data3).not.toContainKeysWithinPercent(keys);
+  expect(data4).not.toContainKeysWithinPercent(keys);
+});
+```
+
 #### .toContainAllKeys([keys])
 
 Use `.toContainAllKeys` when checking if an object only contains all of the provided keys.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-extended",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Additional Jest matchers",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-extended",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Additional Jest matchers",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-extended",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Additional Jest matchers",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/src/matchers/toBeWithinPercent/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeWithinPercent/__snapshots__/index.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toBeWithinPercent fails when given number is within x percent of the mid number 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toBeWithinPercent(</><green>expected</><dim>)</>
+
+Expected number to not be within percent of mid:
+  mid: <green>20</>  percent: <green>100</>%
+Received:
+  <red>25</>"
+`;
+
+exports[`.not.toBeWithinPercent fails when given number is within x percent of the mid number 20`] = `
+"<dim>expect(</><red>received</><dim>).not.toBeWithinPercent(</><green>expected</><dim>)</>
+
+Expected number to not be within percent of mid:
+  mid: <green>20</>  percent: <green>5</>%
+Received:
+  <red>100</>"
+`;
+
+exports[`.toBeWithinPercent fails when given number is not within x percent of the mid number 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeWithinPercent(</><green>expected</><dim>)</>
+
+Expected number to be within percent of mid:
+  mid: <green>20</>  percent: <green>100</>%
+Received:
+  <red>25</>"
+`;

--- a/src/matchers/toBeWithinPercent/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeWithinPercent/__snapshots__/index.test.js.snap
@@ -1,28 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toBeWithinPercent fails when given number is within x percent of the mid number 1`] = `
+exports[`.not.toBeWithinPercent fails when given number is within x percent of the target number 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toBeWithinPercent(</><green>expected</><dim>)</>
 
-Expected number to not be within percent of mid:
-  mid: <green>20</>  percent: <green>100</>%
+Expected number to not be within percent of target:
+  target: <green>20</>  percent: <green>100</>%
 Received:
   <red>25</>"
 `;
 
-exports[`.not.toBeWithinPercent fails when given number is within x percent of the mid number 20`] = `
+exports[`.not.toBeWithinPercent fails when given number is within x percent of the target number 20`] = `
 "<dim>expect(</><red>received</><dim>).not.toBeWithinPercent(</><green>expected</><dim>)</>
 
-Expected number to not be within percent of mid:
-  mid: <green>20</>  percent: <green>5</>%
+Expected number to not be within percent of target:
+  target: <green>20</>  percent: <green>5</>%
 Received:
   <red>100</>"
 `;
 
-exports[`.toBeWithinPercent fails when given number is not within x percent of the mid number 1`] = `
+exports[`.toBeWithinPercent fails when given number is not within x percent of the target number 1`] = `
 "<dim>expect(</><red>received</><dim>).toBeWithinPercent(</><green>expected</><dim>)</>
 
-Expected number to be within percent of mid:
-  mid: <green>20</>  percent: <green>100</>%
+Expected number to be within percent of target:
+  target: <green>20</>  percent: <green>100</>%
 Received:
   <red>25</>"
 `;

--- a/src/matchers/toBeWithinPercent/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeWithinPercent/__snapshots__/index.test.js.snap
@@ -6,13 +6,22 @@ exports[`.not.toBeWithinPercent fails when given number is within x percent of t
 Expected number to not be within percent of target:
   target: <green>20</>  percent: <green>100</>%
 Received:
-  <red>25</>"
+  <red>55</>"
 `;
 
-exports[`.not.toBeWithinPercent fails when given number is within x percent of the target number 20`] = `
+exports[`.not.toBeWithinPercent fails when given number is within x percent of the target number 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toBeWithinPercent(</><green>expected</><dim>)</>
 
 Expected number to not be within percent of target:
+  target: <green>20</>  percent: <green>100</>%
+Received:
+  <red>25</>"
+`;
+
+exports[`.toBeWithinPercent fails when given number is not within x percent of the target number 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeWithinPercent(</><green>expected</><dim>)</>
+
+Expected number to be within percent of target:
   target: <green>20</>  percent: <green>5</>%
 Received:
   <red>100</>"
@@ -22,7 +31,7 @@ exports[`.toBeWithinPercent fails when given number is not within x percent of t
 "<dim>expect(</><red>received</><dim>).toBeWithinPercent(</><green>expected</><dim>)</>
 
 Expected number to be within percent of target:
-  target: <green>20</>  percent: <green>100</>%
+  target: <green>50</>  percent: <green>10</>%
 Received:
-  <red>25</>"
+  <red>56</>"
 `;

--- a/src/matchers/toBeWithinPercent/index.js
+++ b/src/matchers/toBeWithinPercent/index.js
@@ -1,0 +1,30 @@
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+
+import predicate from './predicate';
+
+const passMessage = (number, start, end) => () =>
+  matcherHint('.not.toBeWithin') +
+  '\n\n' +
+  'Expected number to not be within start (inclusive) and end (exclusive):\n' +
+  `  start: ${printExpected(start)}  end: ${printExpected(end)}\n` +
+  'Received:\n' +
+  `  ${printReceived(number)}`;
+
+const failMessage = (number, start, end) => () =>
+  matcherHint('.toBeWithin') +
+  '\n\n' +
+  'Expected number to be within start (inclusive) and end (exclusive):\n' +
+  `  start: ${printExpected(start)}  end: ${printExpected(end)}\n` +
+  'Received:\n' +
+  `  ${printReceived(number)}`;
+
+export default {
+  toBeWithin: (number, start, end) => {
+    const pass = predicate(number, start, end);
+    if (pass) {
+      return { pass: true, message: passMessage(number, start, end) };
+    }
+
+    return { pass: false, message: failMessage(number, start, end) };
+  }
+};

--- a/src/matchers/toBeWithinPercent/index.js
+++ b/src/matchers/toBeWithinPercent/index.js
@@ -2,29 +2,29 @@ import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
 
 import predicate from './predicate';
 
-const passMessage = (number, mid, percent) => () =>
-  matcherHint('.not.toBeWithin') +
+const passMessage = (number, target, percent) => () =>
+  matcherHint('.not.toBeWithinPercent') +
   '\n\n' +
-  'Expected number to not be within percent of mid:\n' +
-  `  mid: ${printExpected(mid)}  percent: ${printExpected(percent)}%\n` +
+  'Expected number to not be within percent of target:\n' +
+  `  target: ${printExpected(target)}  percent: ${printExpected(percent)}%\n` +
   'Received:\n' +
   `  ${printReceived(number)}`;
 
-const failMessage = (number, mid, percent) => () =>
-  matcherHint('.toBeWithin') +
+const failMessage = (number, target, percent) => () =>
+  matcherHint('.toBeWithinPercent') +
   '\n\n' +
-  'Expected number to be within percent of mid:\n' +
-  `  mid: ${printExpected(mid)}  percent: ${printExpected(percent)}%\n` +
+  'Expected number to be within percent of target:\n' +
+  `  target: ${printExpected(target)}  percent: ${printExpected(percent)}%\n` +
   'Received:\n' +
   `  ${printReceived(number)}`;
 
 export default {
-  toBeWithinPercent: (number, mid, percent) => {
-    const pass = predicate(number, mid, percent);
+  toBeWithinPercent: (number, target, percent) => {
+    const pass = predicate(number, target, percent);
     if (pass) {
-      return { pass: true, message: passMessage(number, mid, percent) };
+      return { pass: true, message: passMessage(number, target, percent) };
     }
 
-    return { pass: false, message: failMessage(number, mid, percent) };
+    return { pass: false, message: failMessage(number, target, percent) };
   }
 };

--- a/src/matchers/toBeWithinPercent/index.js
+++ b/src/matchers/toBeWithinPercent/index.js
@@ -2,29 +2,29 @@ import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
 
 import predicate from './predicate';
 
-const passMessage = (number, start, end) => () =>
+const passMessage = (number, mid, percent) => () =>
   matcherHint('.not.toBeWithin') +
   '\n\n' +
-  'Expected number to not be within start (inclusive) and end (exclusive):\n' +
-  `  start: ${printExpected(start)}  end: ${printExpected(end)}\n` +
+  'Expected number to not be within percent of mid:\n' +
+  `  mid: ${printExpected(mid)}  percent: ${printExpected(percent)}%\n` +
   'Received:\n' +
   `  ${printReceived(number)}`;
 
-const failMessage = (number, start, end) => () =>
+const failMessage = (number, mid, percent) => () =>
   matcherHint('.toBeWithin') +
   '\n\n' +
-  'Expected number to be within start (inclusive) and end (exclusive):\n' +
-  `  start: ${printExpected(start)}  end: ${printExpected(end)}\n` +
+  'Expected number to be within percent of mid:\n' +
+  `  mid: ${printExpected(mid)}  percent: ${printExpected(percent)}%\n` +
   'Received:\n' +
   `  ${printReceived(number)}`;
 
 export default {
-  toBeWithin: (number, start, end) => {
-    const pass = predicate(number, start, end);
+  toBeWithinPercent: (number, mid, percent) => {
+    const pass = predicate(number, mid, percent);
     if (pass) {
-      return { pass: true, message: passMessage(number, start, end) };
+      return { pass: true, message: passMessage(number, mid, percent) };
     }
 
-    return { pass: false, message: failMessage(number, start, end) };
+    return { pass: false, message: failMessage(number, mid, percent) };
   }
 };

--- a/src/matchers/toBeWithinPercent/index.test.js
+++ b/src/matchers/toBeWithinPercent/index.test.js
@@ -2,22 +2,22 @@ import matcher from './';
 
 expect.extend(matcher);
 
-describe('.toBeWithin', () => {
-  test('passes when given number is within x percent of the mid number', () => {
+describe('.toBeWithinPercent', () => {
+  test('passes when given number is within x percent of the target number', () => {
     expect(55).toBeWithinPercent(50, 10);
   });
 
-  test('fails when given number is not within x percent of the mid number', () => {
+  test('fails when given number is not within x percent of the target number', () => {
     expect(() => expect(56).toBeWithinPercent(50, 10)).toThrowErrorMatchingSnapshot();
   });
 });
 
-describe('.not.toBeWithin', () => {
-  test('passes when given number is not within x percent of the mid number', () => {
+describe('.not.toBeWithinPercent', () => {
+  test('passes when given number is not within x percent of the target number', () => {
     expect(100).not.toBeWithinPercent(20, 5);
   });
 
-  test('fails when given number is within x percent of the mid number', () => {
+  test('fails when given number is within x percent of the target number', () => {
     expect(() => expect(25).not.toBeWithinPercent(20, 100)).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeWithinPercent/index.test.js
+++ b/src/matchers/toBeWithinPercent/index.test.js
@@ -3,21 +3,21 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeWithin', () => {
-  test('passes when given number is within the given bounds of start (inclusive) and end (exclusive)', () => {
-    expect(1).toBeWithin(1, 3);
+  test('passes when given number is within x percent of the mid number', () => {
+    expect(55).toBeWithinPercent(50, 10);
   });
 
-  test('fails when given number is not within the given bounds of start (inclusive) and end (exclusive)', () => {
-    expect(() => expect(3).toBeWithin(1, 3)).toThrowErrorMatchingSnapshot();
+  test('fails when given number is not within x percent of the mid number', () => {
+    expect(() => expect(56).toBeWithinPercent(50, 10)).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeWithin', () => {
-  test('passes when given number is not within the given bounds of start (inclusive) and end (exclusive)', () => {
-    expect(3).not.toBeWithin(1, 3);
+  test('passes when given number is not within x percent of the mid number', () => {
+    expect(100).not.toBeWithinPercent(20, 5);
   });
 
-  test('fails when given number is within the given bounds of start (inclusive) and end (exclusive)', () => {
-    expect(() => expect(1).not.toBeWithin(1, 3)).toThrowErrorMatchingSnapshot();
+  test('fails when given number is within x percent of the mid number', () => {
+    expect(() => expect(25).not.toBeWithinPercent(20, 100)).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeWithinPercent/index.test.js
+++ b/src/matchers/toBeWithinPercent/index.test.js
@@ -1,0 +1,23 @@
+import matcher from './';
+
+expect.extend(matcher);
+
+describe('.toBeWithin', () => {
+  test('passes when given number is within the given bounds of start (inclusive) and end (exclusive)', () => {
+    expect(1).toBeWithin(1, 3);
+  });
+
+  test('fails when given number is not within the given bounds of start (inclusive) and end (exclusive)', () => {
+    expect(() => expect(3).toBeWithin(1, 3)).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toBeWithin', () => {
+  test('passes when given number is not within the given bounds of start (inclusive) and end (exclusive)', () => {
+    expect(3).not.toBeWithin(1, 3);
+  });
+
+  test('fails when given number is within the given bounds of start (inclusive) and end (exclusive)', () => {
+    expect(() => expect(1).not.toBeWithin(1, 3)).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/toBeWithinPercent/predicate.js
+++ b/src/matchers/toBeWithinPercent/predicate.js
@@ -1,1 +1,1 @@
-export default (number, mid, percent) => number < mid * (1 + percent / 100) && number > mid * (1 - percent / 100);
+export default (number, mid, percent) => number <= mid * (1 + percent / 100) && number >= mid * (1 - percent / 100);

--- a/src/matchers/toBeWithinPercent/predicate.js
+++ b/src/matchers/toBeWithinPercent/predicate.js
@@ -1,0 +1,1 @@
+export default (number, mid, percent) => number < mid * (1 + percent / 100) && number > mid * (1 - percent / 100);

--- a/src/matchers/toBeWithinPercent/predicate.js
+++ b/src/matchers/toBeWithinPercent/predicate.js
@@ -1,1 +1,2 @@
-export default (number, mid, percent) => number <= mid * (1 + percent / 100) && number >= mid * (1 - percent / 100);
+export default (number, target, percent) =>
+  number <= target * (1 + percent / 100) && number >= target * (1 - percent / 100);

--- a/src/matchers/toBeWithinPercent/predicate.test.js
+++ b/src/matchers/toBeWithinPercent/predicate.test.js
@@ -1,0 +1,11 @@
+import predicate from './predicate';
+
+describe('toBeWithinPercent Predicate', () => {
+  test('returns true when given number is within percent of mid', () => {
+    expect(predicate(75, 50, 100)).toBe(true);
+  });
+
+  test('returns false when given number is not within percent of mid', () => {
+    expect(predicate(70, 50, 10)).toBe(false);
+  });
+});

--- a/src/matchers/toBeWithinPercent/predicate.test.js
+++ b/src/matchers/toBeWithinPercent/predicate.test.js
@@ -2,10 +2,10 @@ import predicate from './predicate';
 
 describe('toBeWithinPercent Predicate', () => {
   test('returns true when given number is within percent of mid', () => {
-    expect(predicate(75, 50, 100)).toBe(true);
+    expect(predicate(55, 50, 10)).toBe(true);
   });
 
   test('returns false when given number is not within percent of mid', () => {
-    expect(predicate(70, 50, 10)).toBe(false);
+    expect(predicate(60, 50, 10)).toBe(false);
   });
 });

--- a/src/matchers/toBeWithinPercent/predicate.test.js
+++ b/src/matchers/toBeWithinPercent/predicate.test.js
@@ -1,11 +1,11 @@
 import predicate from './predicate';
 
 describe('toBeWithinPercent Predicate', () => {
-  test('returns true when given number is within percent of mid', () => {
+  test('returns true when given number is within percent of target', () => {
     expect(predicate(55, 50, 10)).toBe(true);
   });
 
-  test('returns false when given number is not within percent of mid', () => {
+  test('returns false when given number is not within percent of target', () => {
     expect(predicate(60, 50, 10)).toBe(false);
   });
 });

--- a/src/matchers/toContainKeysWithinPercent/__snapshots__/index.test.js.snap
+++ b/src/matchers/toContainKeysWithinPercent/__snapshots__/index.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toContainKeys fails when object contains all keys and they are within x percent of target 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toContainKeysWithinPercent(</><green>expected</><dim>)</>
+
+Expected object to not contain all keys or the keys' values to not be within x percent of target:
+  <green>[{\\"key\\": \\"a\\", \\"percent\\": 10, \\"target\\": 50}, {\\"key\\": \\"b\\", \\"percent\\": 0, \\"target\\": 5}, {\\"key\\": \\"c\\", \\"percent\\": 100, \\"target\\": 1}]</>
+Received:
+  <red>{\\"a\\": 55, \\"b\\": 5, \\"c\\": 1}</>"
+`;
+
+exports[`.not.toContainKeysWithinPercent fails when object contains all keys 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toContainKeysWithinPercent(</><green>expected</><dim>)</>
+
+Expected object to contain all keys and the keys' values to be within x percent of target:
+  <green>[\\"a\\", \\"b\\", \\"c\\"]</>
+Received:
+  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
+`;
+
+exports[`.not.toContainKeysWithinPercent fails when object contains all keys and they are within x percent of target 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toContainKeysWithinPercent(</><green>expected</><dim>)</>
+
+Expected object to not contain all keys or the keys' values to not be within x percent of target:
+  <green>[{\\"key\\": \\"a\\", \\"percent\\": 10, \\"target\\": 50}, {\\"key\\": \\"b\\", \\"percent\\": 0, \\"target\\": 5}, {\\"key\\": \\"c\\", \\"percent\\": 100, \\"target\\": 1}]</>
+Received:
+  <red>{\\"a\\": 55, \\"b\\": 5, \\"c\\": 1}</>"
+`;
+
+exports[`.toContainKeys fails when object does not contain all keys or they are not within x percent of target 1`] = `
+"<dim>expect(</><red>received</><dim>).toContainKeysWithinPercent(</><green>expected</><dim>)</>
+
+Expected object to contain all keys and the keys' values to be within x percent of target:
+  <green>[{\\"key\\": \\"a\\", \\"percent\\": 10, \\"target\\": 50}, {\\"key\\": \\"b\\", \\"percent\\": 0, \\"target\\": 5}, {\\"key\\": \\"c\\", \\"percent\\": 100, \\"target\\": 1}]</>
+Received:
+  <red>{\\"a\\": 56, \\"b\\": 5, \\"c\\": 1}</>"
+`;
+
+exports[`.toContainKeysWithinPercent fails when object does not contain all keys or they are not within x percent of target 1`] = `"expect(...).toContainKeyWithinPercent is not a function"`;

--- a/src/matchers/toContainKeysWithinPercent/__snapshots__/index.test.js.snap
+++ b/src/matchers/toContainKeysWithinPercent/__snapshots__/index.test.js.snap
@@ -9,24 +9,6 @@ Received:
   <red>{\\"a\\": 55, \\"b\\": 5, \\"c\\": 1}</>"
 `;
 
-exports[`.not.toContainKeysWithinPercent fails when object contains all keys 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainKeysWithinPercent(</><green>expected</><dim>)</>
-
-Expected object to contain all keys and the keys' values to be within x percent of target:
-  <green>[\\"a\\", \\"b\\", \\"c\\"]</>
-Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</>"
-`;
-
-exports[`.not.toContainKeysWithinPercent fails when object contains all keys and they are within x percent of target 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toContainKeysWithinPercent(</><green>expected</><dim>)</>
-
-Expected object to not contain all keys or the keys' values to not be within x percent of target:
-  <green>[{\\"key\\": \\"a\\", \\"percent\\": 10, \\"target\\": 50}, {\\"key\\": \\"b\\", \\"percent\\": 0, \\"target\\": 5}, {\\"key\\": \\"c\\", \\"percent\\": 100, \\"target\\": 1}]</>
-Received:
-  <red>{\\"a\\": 55, \\"b\\": 5, \\"c\\": 1}</>"
-`;
-
 exports[`.toContainKeys fails when object does not contain all keys or they are not within x percent of target 1`] = `
 "<dim>expect(</><red>received</><dim>).toContainKeysWithinPercent(</><green>expected</><dim>)</>
 
@@ -35,5 +17,3 @@ Expected object to contain all keys and the keys' values to be within x percent 
 Received:
   <red>{\\"a\\": 56, \\"b\\": 5, \\"c\\": 1}</>"
 `;
-
-exports[`.toContainKeysWithinPercent fails when object does not contain all keys or they are not within x percent of target 1`] = `"expect(...).toContainKeyWithinPercent is not a function"`;

--- a/src/matchers/toContainKeysWithinPercent/index.js
+++ b/src/matchers/toContainKeysWithinPercent/index.js
@@ -1,0 +1,30 @@
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+
+import predicate from './predicate';
+
+const passMessage = (valueObj, keysArray) => () =>
+  matcherHint('.not.toContainKeysWithinPercent') +
+  '\n\n' +
+  "Expected object to not contain all keys or the keys' values to not be within x percent of target:\n" +
+  `  ${printExpected(keysArray)}\n` +
+  'Received:\n' +
+  `  ${printReceived(valueObj)}`;
+
+const failMessage = (valueObj, keysArray) => () =>
+  matcherHint('.toContainKeysWithinPercent') +
+  '\n\n' +
+  "Expected object to contain all keys and the keys' values to be within x percent of target:\n" +
+  `  ${printExpected(keysArray)}\n` +
+  'Received:\n' +
+  `  ${printReceived(valueObj)}`;
+
+export default {
+  toContainKeysWithinPercent: (valueObj, keysArray) => {
+    const pass = predicate(valueObj, keysArray);
+    if (pass) {
+      return { pass: true, message: passMessage(valueObj, keysArray) };
+    }
+
+    return { pass: false, message: failMessage(valueObj, keysArray) };
+  }
+};

--- a/src/matchers/toContainKeysWithinPercent/index.test.js
+++ b/src/matchers/toContainKeysWithinPercent/index.test.js
@@ -1,0 +1,43 @@
+import matcher from './';
+
+expect.extend(matcher);
+
+const data1 = { a: 55, b: 5, c: 1 };
+const data2 = { a: 56, b: 5, c: 1 };
+
+const keys = [
+  {
+    key: 'a',
+    target: 50,
+    percent: 10
+  },
+  {
+    key: 'b',
+    target: 5,
+    percent: 0
+  },
+  {
+    key: 'c',
+    target: 1,
+    percent: 100
+  }
+];
+describe('.toContainKeys', () => {
+  test('passes when object contains all keys and they are within x percent of target', () => {
+    expect(data1).toContainKeysWithinPercent(keys);
+  });
+
+  test('fails when object does not contain all keys or they are not within x percent of target', () => {
+    expect(() => expect(data2).toContainKeysWithinPercent(keys)).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toContainKeys', () => {
+  test('passes when object does not contain all keys or they are not within x percent of target', () => {
+    expect(data2).not.toContainKeysWithinPercent(keys);
+  });
+
+  test('fails when object contains all keys and they are within x percent of target', () => {
+    expect(() => expect(data1).not.toContainKeysWithinPercent(keys)).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/toContainKeysWithinPercent/predicate.js
+++ b/src/matchers/toContainKeysWithinPercent/predicate.js
@@ -1,0 +1,8 @@
+export default (valueObj, keys) =>
+  keys.every(keyObj => {
+    return (
+      valueObj[keyObj.key] &&
+      valueObj[keyObj.key] <= keyObj.target * (1 + keyObj.percent / 100) &&
+      valueObj[keyObj.key] >= keyObj.target * (1 - keyObj.percent / 100)
+    );
+  });

--- a/src/matchers/toContainKeysWithinPercent/predicate.test.js
+++ b/src/matchers/toContainKeysWithinPercent/predicate.test.js
@@ -1,0 +1,32 @@
+import predicate from './predicate';
+
+const data1 = { a: 55, b: 5, c: 1 };
+const data2 = { a: 56, b: 5, c: 1 };
+
+const keys = [
+  {
+    key: 'a',
+    target: 50,
+    percent: 10
+  },
+  {
+    key: 'b',
+    target: 5,
+    percent: 0
+  },
+  {
+    key: 'c',
+    target: 1,
+    percent: 100
+  }
+];
+
+describe('.toContainKeysWithinPercent', () => {
+  test('passes when object contains all keys and they are within x percent of target', () => {
+    expect(predicate(data1, keys)).toBe(true);
+  });
+
+  test('fails when object does not contain all keys or they are not within x percent of target', () => {
+    expect(predicate(data2, keys)).toBe(false);
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@
 
 declare namespace jest {
   // noinspection JSUnusedGlobalSymbols
-  interface Matchers<R> {
+  interface Matchers<R, T> {
     /**
      * Note: Currently unimplemented
      * Passing assertion

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@
 
 declare namespace jest {
   // noinspection JSUnusedGlobalSymbols
-  interface Matchers<R, T> {
+  interface Matchers<R, T = void> {
     /**
      * Note: Currently unimplemented
      * Passing assertion

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@
 
 declare namespace jest {
   // noinspection JSUnusedGlobalSymbols
-  interface Matchers<R, T = void> {
+  interface Matchers<R> {
     /**
      * Note: Currently unimplemented
      * Passing assertion

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -293,12 +293,12 @@ declare namespace jest {
     /**
      * Use `.toResolve` when checking if a promise resolves.
      */
-    toResolve(): R;
+    toResolve(): Promise<R>;
 
     /**
      * Use `.toReject` when checking if a promise rejects.
      */
-    toReject(): R;
+    toReject(): Promise<R>;
 
     /**
      * Use `.toBeString` when checking if a value is a `String`.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -570,6 +570,13 @@ declare namespace jest {
     toContainKeys(keys: string[]): any;
 
     /**
+     * Use `.toContainKeysWithinPercent` when checking if an object has all of the provided keys and the keys' values are within x percent of a target value.
+     *
+     * @param {Array.<Object>} keyObjects
+     */
+    toContainKeysWithinPercent(keyObjects: object[]): any;
+
+    /**
      * Use `.toContainAllKeys` when checking if an object only contains all of the provided keys.
      *
      * @param {Array.<String>} keys

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -187,6 +187,14 @@ declare namespace jest {
     toBeWithin(start: number, end: number): R;
 
     /**
+     * Use `.toBeWithinPercent` when checking if a number is within x percent of a target number.
+     *
+     * @param {Number} target
+     * @param {Number} percent
+     */
+    toBeWithinPercent(target: number, percent: number): R;
+
+    /**
      * Use `.toBeObject` when checking if a value is an `Object`.
      */
     toBeObject(): R;


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/301.

> ### What
> Created a toBeWithinPercent function to check if a number is within x percent of a target number, and toContainKeysWithinPercent function to check if an object contains keys and if the keys' values are within x percent of a target number.
> 
> ### Why
> To be used similarly to the toBeWithin function, but sometimes a percentage is needed rather than a range.
> 
> The toContainKeysWithinPercent function is for a similar purpose but for use within an object.
> 
> ### Notes
> ### Housekeeping
> * [x]  Unit tests
> * [x]  Documentation is up to date
> * [x]  No additional lint warnings
> * [x]  [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant