### PR TITLE
Validate if spy or mock was passed when expected

### DIFF
--- a/src/matchers/toHaveBeenCalledAfter/__snapshots__/index.test.js.snap
+++ b/src/matchers/toHaveBeenCalledAfter/__snapshots__/index.test.js.snap
@@ -45,6 +45,15 @@ Received second mock with invocationCallOrder:
   <red>[]</>"
 `;
 
+exports[`.toHaveBeenCalledAfter fails when given first value is not a jest spy or mock 1`] = `
+"<dim>expect(</><red>received</><dim>).toHaveBeenCalledAfter(</><green>expected</><dim>)</>
+
+Matcher error: <red>\\"received\\"</> must be a mock or spy function
+
+Received:
+  function: <red>[Function mock1]</>"
+`;
+
 exports[`.toHaveBeenCalledAfter fails when given second mock is called after first mock 1`] = `
 "<dim>expect(</><red>received</><dim>).toHaveBeenCalledAfter(</><green>expected</><dim>)</>
 
@@ -52,4 +61,13 @@ Expected first mock to have been called after, invocationCallOrder:
   <green>[4000]</>
 Received second mock with invocationCallOrder:
   <red>[5000]</>"
+`;
+
+exports[`.toHaveBeenCalledAfter fails when given second value is not a jest spy or mock 1`] = `
+"<dim>expect(</><red>received</><dim>).toHaveBeenCalledAfter(</><green>expected</><dim>)</>
+
+Matcher error: <green>\\"expected\\"</> must be a mock or spy function
+
+Expected:
+  function: <green>[Function mock2]</>"
 `;

--- a/src/matchers/toHaveBeenCalledAfter/index.js
+++ b/src/matchers/toHaveBeenCalledAfter/index.js
@@ -1,4 +1,6 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+import { matcherHint, printExpected, printReceived, printWithType } from 'jest-matcher-utils';
+
+import { isJestMockOrSpy } from '../../utils';
 
 import predicate from './predicate';
 
@@ -18,8 +20,29 @@ const failMessage = (firstInvocationCallOrder, secondInvocationCallOrder) => () 
   'Received second mock with invocationCallOrder:\n' +
   `  ${printReceived(secondInvocationCallOrder)}`;
 
+const mockCheckFailMessage = (value, isReceivedValue) => () => {
+  const valueKind = isReceivedValue ? 'Received' : 'Expected';
+  const valueKindPrintFunc = isReceivedValue ? printReceived : printExpected;
+
+  return (
+    matcherHint('.toHaveBeenCalledAfter') +
+    '\n\n' +
+    `Matcher error: ${valueKindPrintFunc(valueKind.toLowerCase())} must be a mock or spy function` +
+    '\n\n' +
+    printWithType(valueKind, value, valueKindPrintFunc)
+  );
+};
+
 export default {
   toHaveBeenCalledAfter: (firstMock, secondMock) => {
+    if (!isJestMockOrSpy(firstMock)) {
+      return { pass: false, message: mockCheckFailMessage(firstMock, true) };
+    }
+
+    if (!isJestMockOrSpy(secondMock)) {
+      return { pass: false, message: mockCheckFailMessage(secondMock, false) };
+    }
+
     const firstInvocationCallOrder = firstMock.mock.invocationCallOrder;
     const secondInvocationCallOrder = secondMock.mock.invocationCallOrder;
     const pass = predicate(firstInvocationCallOrder, secondInvocationCallOrder);

--- a/src/matchers/toHaveBeenCalledAfter/index.test.js
+++ b/src/matchers/toHaveBeenCalledAfter/index.test.js
@@ -58,6 +58,18 @@ describe('.toHaveBeenCalledAfter', () => {
     mock2.mock.invocationCallOrder[0] = 4000;
     expect(mock1).toHaveBeenCalledAfter(mock2);
   });
+
+  test('fails when given first value is not a jest spy or mock', () => {
+    const mock1 = () => {};
+    const mock2 = jest.fn();
+    expect(() => expect(mock1).toHaveBeenCalledAfter(mock2)).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when given second value is not a jest spy or mock', () => {
+    const mock1 = jest.fn();
+    const mock2 = () => {};
+    expect(() => expect(mock1).toHaveBeenCalledAfter(mock2)).toThrowErrorMatchingSnapshot();
+  });
 });
 
 describe('.not.toHaveBeenCalledAfter', () => {

--- a/src/matchers/toHaveBeenCalledBefore/__snapshots__/index.test.js.snap
+++ b/src/matchers/toHaveBeenCalledBefore/__snapshots__/index.test.js.snap
@@ -53,3 +53,21 @@ Expected first mock to have been called before, invocationCallOrder:
 Received second mock with invocationCallOrder:
   <red>[4000]</>"
 `;
+
+exports[`.toHaveBeenCalledBefore fails when given first value is not a jest spy or mock 1`] = `
+"<dim>expect(</><red>received</><dim>).toHaveBeenCalledAfter(</><green>expected</><dim>)</>
+
+Matcher error: <red>\\"received\\"</> must be a mock or spy function
+
+Received:
+  function: <red>[Function mock1]</>"
+`;
+
+exports[`.toHaveBeenCalledBefore fails when given second value is not a jest spy or mock 1`] = `
+"<dim>expect(</><red>received</><dim>).toHaveBeenCalledAfter(</><green>expected</><dim>)</>
+
+Matcher error: <green>\\"expected\\"</> must be a mock or spy function
+
+Expected:
+  function: <green>[Function mock2]</>"
+`;

--- a/src/matchers/toHaveBeenCalledBefore/index.js
+++ b/src/matchers/toHaveBeenCalledBefore/index.js
@@ -1,4 +1,6 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+import { matcherHint, printExpected, printReceived, printWithType } from 'jest-matcher-utils';
+
+import { isJestMockOrSpy } from '../../utils';
 
 import predicate from './predicate';
 
@@ -18,8 +20,29 @@ const failMessage = (firstInvocationCallOrder, secondInvocationCallOrder) => () 
   'Received second mock with invocationCallOrder:\n' +
   `  ${printReceived(secondInvocationCallOrder)}`;
 
+const mockCheckFailMessage = (value, isReceivedValue) => () => {
+  const valueKind = isReceivedValue ? 'Received' : 'Expected';
+  const valueKindPrintFunc = isReceivedValue ? printReceived : printExpected;
+
+  return (
+    matcherHint('.toHaveBeenCalledAfter') +
+    '\n\n' +
+    `Matcher error: ${valueKindPrintFunc(valueKind.toLowerCase())} must be a mock or spy function` +
+    '\n\n' +
+    printWithType(valueKind, value, valueKindPrintFunc)
+  );
+};
+
 export default {
   toHaveBeenCalledBefore: (firstMock, secondMock) => {
+    if (!isJestMockOrSpy(firstMock)) {
+      return { pass: false, message: mockCheckFailMessage(firstMock, true) };
+    }
+
+    if (!isJestMockOrSpy(secondMock)) {
+      return { pass: false, message: mockCheckFailMessage(secondMock, false) };
+    }
+
     const firstInvocationCallOrder = firstMock.mock.invocationCallOrder;
     const secondInvocationCallOrder = secondMock.mock.invocationCallOrder;
     const pass = predicate(firstInvocationCallOrder, secondInvocationCallOrder);

--- a/src/matchers/toHaveBeenCalledBefore/index.test.js
+++ b/src/matchers/toHaveBeenCalledBefore/index.test.js
@@ -58,6 +58,18 @@ describe('.toHaveBeenCalledBefore', () => {
     mock2.mock.invocationCallOrder[0] = 4000;
     expect(() => expect(mock1).toHaveBeenCalledBefore(mock2)).toThrowErrorMatchingSnapshot();
   });
+
+  test('fails when given first value is not a jest spy or mock', () => {
+    const mock1 = () => {};
+    const mock2 = jest.fn();
+    expect(() => expect(mock1).toHaveBeenCalledBefore(mock2)).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when given second value is not a jest spy or mock', () => {
+    const mock1 = jest.fn();
+    const mock2 = () => {};
+    expect(() => expect(mock1).toHaveBeenCalledBefore(mock2)).toThrowErrorMatchingSnapshot();
+  });
 });
 
 describe('.not.toHaveBeenCalledBefore', () => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -8,4 +8,8 @@ export const determinePropertyMessage = (actual, property, message = 'Not Access
   return actual && actual[property] ? actual[property] : message;
 };
 
+export const isJestMockOrSpy = value => {
+  return !!(value && value._isMockFunction === true && typeof value.mock === 'object');
+};
+
 export { equals };

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -1,6 +1,6 @@
 import each from 'jest-each';
 
-import { contains, determinePropertyMessage } from './';
+import { contains, determinePropertyMessage, isJestMockOrSpy } from './';
 
 describe('Utils', () => {
   describe('.contains', () => {
@@ -41,5 +41,17 @@ describe('Utils', () => {
         expect(determinePropertyMessage(fn, 'length', errorMessage)).toBe(errorMessage);
       });
     }
+  });
+
+  describe('.isJestMockOrSpy', () => {
+    test('returns true if value is a jest mock', () => {
+      const spy = jest.fn();
+      expect(isJestMockOrSpy(spy)).toBe(true);
+    });
+
+    test('returns false if value is not a jest mock', () => {
+      const fn = () => {};
+      expect(isJestMockOrSpy(fn)).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Copy of https://github.com/jest-community/jest-extended/pull/203.

> ### What
> Add error to `toHaveBeenCalledBefore` and `toHaveBeenCalledAfter` matchers in case passed params are not instances of `jest.Mock`
> 
> ### Why
> Jest has similar errors when non spy or mock is passed to `toHaveBeenCalled` or other mock-related matchers.
> 
> * [x]  Unit tests
> * [x]  No additional lint warnings